### PR TITLE
Add openlayers example to tegola-osm

### DIFF
--- a/docs/openlayers/index.html
+++ b/docs/openlayers/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset='utf-8' />
+		<title></title>
+		<meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Open+Sans" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/openlayers/4.2.0/ol.css">
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=Promise"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/openlayers/4.2.0/ol.js"></script>
+		<script src='js/olms.js'></script>
+		<style>
+			body { margin:0; padding:0; }
+			#map { position:absolute; top:0; bottom:0; width:100%; }
+		</style>
+	</head>
+	<body>
+	<div id='map'></div>
+	<script>
+    var map = olms.apply('map', 'js/mapbox.json');
+    map.getView().setCenter(ol.proj.fromLonLat([-117.15117725013909, 32.72269876352742]));
+    map.getView().setZoom(15);
+	</script>
+	</body>
+</html>

--- a/docs/openlayers/js/mapbox.json
+++ b/docs/openlayers/js/mapbox.json
@@ -1,0 +1,3811 @@
+{
+  "version": 8,
+  "name": "HOTOSMstyle",
+  "metadata": {
+    "mapbox:autocomposite": false,
+    "mapbox:type": "template",
+    "maputnik:renderer": "mbgljs",
+    "openmaptiles:version": "3.x",
+    "openmaptiles:mapbox:owner": "openmaptiles",
+    "openmaptiles:mapbox:source:url": "mapbox://openmaptiles.4qljc88t"
+  },
+  "center": [
+    8.54806714892635,
+    47.37180823552663
+  ],
+  "zoom": 12.241790506353492,
+  "bearing": 0,
+  "pitch": 0,
+  "sources": {
+    "tegola-osm": {
+      "type": "vector",
+      "url": "http://tegola-cdn.terranodo.io/capabilities/osm.json?debug=true"
+    }
+  },
+  "glyphs": "https://free.tilehosting.com/fonts/{fontstack}/{range}.pbf?key={key}",
+  "layers": [
+    {
+      "id": "background",
+      "type": "background",
+      "minzoom": 0,
+      "maxzoom": 20,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "background-color": "rgba(144, 204, 203, 1)"
+      }
+    },
+    {
+      "id": "land_10-20",
+      "type": "fill",
+      "source": "tegola-osm",
+      "source-layer": "land_10-20",
+      "minzoom": 10,
+      "maxzoom": 20,
+      "paint": {
+        "fill-color": "rgba(247, 246, 241, 1)"
+      }
+    },
+    {
+      "id": "land_0-9",
+      "type": "fill",
+      "source": "tegola-osm",
+      "source-layer": "land_0-9",
+      "maxzoom": 10,
+      "paint": {
+        "fill-color": "rgba(247, 246, 241, 1)"
+      }
+    },
+    {
+      "id": "landusages",
+      "type": "fill",
+      "source": "tegola-osm",
+      "source-layer": "landusages",
+      "minzoom": 13,
+      "maxzoom": 24,
+      "paint": {
+        "fill-color": {
+          "property": "type",
+          "type": "categorical",
+          "stops": [
+            [
+              "",
+              "rgba(202, 57, 57, 0)"
+            ],
+            [
+              "wetland",
+              "rgba(227, 233, 226, 1)"
+            ],
+            [
+              "military",
+              "rgba(209, 191, 170, 1)"
+            ],
+            [
+              "salt_pond",
+              "rgba(236, 240, 241, 1)"
+            ],
+            [
+              "basin",
+              "rgba(144, 204, 203, 1)"
+            ],
+            [
+              "beach",
+              "rgba(238, 229, 178, 1)"
+            ],
+            [
+              "desert",
+              "rgba(238, 229, 178, 1)"
+            ],
+            [
+              "farmland",
+              "rgba(222, 221, 190, 1)"
+            ],
+            [
+              "farm",
+              "rgba(222, 221, 190, 1)"
+            ],
+            [
+              "orchard",
+              "rgba(222, 221, 190, 1)"
+            ],
+            [
+              "allotments",
+              "rgba(222, 221, 190, 1)"
+            ],
+            [
+              "heath",
+              "rgba(225, 233, 214, 1)"
+            ],
+            [
+              "meadow",
+              "rgba(225, 233, 214, 1)"
+            ],
+            [
+              "residential",
+              "rgba(237, 236, 231, 1)"
+            ],
+            [
+              "retail",
+              "rgba(237, 236, 231, 1)"
+            ],
+            [
+              "industrial",
+              "rgba(215, 200, 203, 1)"
+            ],
+            [
+              "quarry",
+              "rgba(215, 200, 203, 1)"
+            ],
+            [
+              "landfill",
+              "rgba(215, 200, 203, 1)"
+            ],
+            [
+              "college",
+              "rgba(226, 214, 205, 1)"
+            ],
+            [
+              "school",
+              "rgba(226, 214, 205, 1)"
+            ],
+            [
+              "education",
+              "rgba(226, 214, 205, 1)"
+            ],
+            [
+              "university",
+              "rgba(226, 214, 205, 1)"
+            ],
+            [
+              "cemetery",
+              "rgba(214, 222, 210, 1)"
+            ],
+            [
+              "grave_yard",
+              "rgba(214, 222, 210, 1)"
+            ],
+            [
+              "park",
+              "rgba(208, 220, 174, 1)"
+            ],
+            [
+              "sports_centre",
+              "rgba(208, 220, 174, 1)"
+            ],
+            [
+              "stadium",
+              "rgba(208, 220, 174, 1)"
+            ],
+            [
+              "grass",
+              "rgba(208, 220, 174, 1)"
+            ],
+            [
+              "grassland",
+              "rgba(208, 220, 174, 1)"
+            ],
+            [
+              "garden",
+              "rgba(208, 220, 174, 1)"
+            ],
+            [
+              "village_green",
+              "rgba(208, 220, 174, 1)"
+            ],
+            [
+              "recreation_ground",
+              "rgba(208, 220, 174, 1)"
+            ],
+            [
+              "picnic_site",
+              "rgba(208, 220, 174, 1)"
+            ],
+            [
+              "camp_site",
+              "rgba(208, 220, 174, 1)"
+            ],
+            [
+              "playground",
+              "rgba(208, 220, 174, 1)"
+            ],
+            [
+              "forest",
+              "rgba(178, 194, 157, 1)"
+            ],
+            [
+              "wood",
+              "rgba(178, 194, 157, 1)"
+            ],
+            [
+              "nature_reserve",
+              "rgba(178, 194, 157, 1)"
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "landusages_gen1forest",
+      "type": "fill",
+      "source": "tegola-osm",
+      "source-layer": "landusages_gen1",
+      "minzoom": 10,
+      "maxzoom": 13,
+      "filter": [
+        "all",
+        [
+          "in",
+          "type",
+          "forest",
+          "wood",
+          "nature_reserve"
+        ]
+      ],
+      "paint": {
+        "fill-color": "rgba(178, 194, 157, 1)"
+      }
+    },
+    {
+      "id": "landusages_gen1park",
+      "type": "fill",
+      "source": "tegola-osm",
+      "source-layer": "landusages_gen1",
+      "minzoom": 10,
+      "maxzoom": 13,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "park"
+        ]
+      ],
+      "paint": {
+        "fill-color": "rgba(208, 220, 174, 1)"
+      }
+    },
+    {
+      "id": "landusages_gen0_z9",
+      "type": "fill",
+      "source": "tegola-osm",
+      "source-layer": "landusages_gen0",
+      "minzoom": 7,
+      "maxzoom": 10,
+      "filter": [
+        "all",
+        [
+          "in",
+          "type",
+          "forest",
+          "wood",
+          "nature_reserve"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "rgba(178, 194, 157, 1)"
+      }
+    },
+    {
+      "id": "landusages_gen0_z7",
+      "type": "fill",
+      "source": "tegola-osm",
+      "source-layer": "landusages_gen0",
+      "minzoom": 5,
+      "maxzoom": 7,
+      "filter": [
+        "all",
+        [
+          "in",
+          "type",
+          "forest",
+          "wood"
+        ],
+        [
+          ">",
+          "area",
+          50000000
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "rgba(178, 194, 157, 1)"
+      }
+    },
+    {
+      "id": "landusages_gen0_z5",
+      "type": "fill",
+      "source": "tegola-osm",
+      "source-layer": "landusages_gen0",
+      "minzoom": 3,
+      "maxzoom": 5,
+      "filter": [
+        "all",
+        [
+          "in",
+          "type",
+          "forest",
+          "wood"
+        ],
+        [
+          ">",
+          "area",
+          500000000
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "rgba(178, 194, 157, 1)"
+      }
+    },
+    {
+      "id": "buildings_flat",
+      "type": "fill",
+      "source": "tegola-osm",
+      "source-layer": "buildings",
+      "minzoom": 14,
+      "maxzoom": 24,
+      "filter": [
+        "all"
+      ],
+      "layout": {
+        "visibility": "none"
+      },
+      "paint": {
+        "fill-color": "rgba(220, 215, 215, 1)",
+        "fill-outline-color": "rgba(195, 188, 188, 1)"
+      }
+    },
+    {
+      "id": "waterways",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "waterways",
+      "minzoom": 15,
+      "maxzoom": 20,
+      "filter": [
+        "all",
+        [
+          "!in",
+          "type",
+          "stream",
+          "drain",
+          "ditch"
+        ]
+      ],
+      "paint": {
+        "line-color": "rgba(144, 204, 203, 1)",
+        "line-width": {
+          "stops": [
+            [
+              15,
+              5
+            ],
+            [
+              20,
+              8
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "waterways_stream",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "waterways",
+      "minzoom": 15,
+      "maxzoom": 20,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "stream"
+        ]
+      ],
+      "paint": {
+        "line-color": "rgba(144, 204, 203, 1)",
+        "line-width": {
+          "stops": [
+            [
+              15,
+              0.8
+            ],
+            [
+              20,
+              2
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "waterways_ditch",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "waterways",
+      "minzoom": 15,
+      "maxzoom": 20,
+      "filter": [
+        "all",
+        [
+          "in",
+          "type",
+          "ditch",
+          "drain"
+        ]
+      ],
+      "paint": {
+        "line-color": "rgba(144, 204, 203, 1)",
+        "line-width": {
+          "stops": [
+            [
+              15,
+              0.2
+            ],
+            [
+              20,
+              1.5
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "waterways_gen1",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "waterways_gen1",
+      "minzoom": 13,
+      "maxzoom": 15,
+      "filter": [
+        "all",
+        [
+          "!=",
+          "type",
+          "stream"
+        ]
+      ],
+      "paint": {
+        "line-color": "rgba(144, 204, 203, 1)",
+        "line-width": {
+          "stops": [
+            [
+              13,
+              1
+            ],
+            [
+              14,
+              1.5
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "waterways_gen1stream",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "waterways_gen1",
+      "minzoom": 13,
+      "maxzoom": 15,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "stream"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(144, 204, 203, 1)",
+        "line-width": {
+          "stops": [
+            [
+              13,
+              0.5
+            ],
+            [
+              14,
+              0.8
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "waterways_gen0",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "waterways_gen0",
+      "minzoom": 8,
+      "maxzoom": 13,
+      "filter": [
+        "all",
+        [
+          "in",
+          "type",
+          "river",
+          "canal"
+        ]
+      ],
+      "paint": {
+        "line-color": "rgba(144, 204, 203, 1)",
+        "line-width": {
+          "stops": [
+            [
+              8,
+              0.1
+            ],
+            [
+              13,
+              0.8
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "waterareas",
+      "type": "fill",
+      "source": "tegola-osm",
+      "source-layer": "waterareas",
+      "minzoom": 13,
+      "maxzoom": 20,
+      "paint": {
+        "fill-color": "rgba(144, 204, 203, 1)"
+      }
+    },
+    {
+      "id": "waterareas_gen1",
+      "type": "fill",
+      "source": "tegola-osm",
+      "source-layer": "waterareas_gen1",
+      "minzoom": 10,
+      "maxzoom": 13,
+      "paint": {
+        "fill-color": "rgba(144, 204, 203, 1)"
+      }
+    },
+    {
+      "id": "waterareas_gen0_z9",
+      "type": "fill",
+      "source": "tegola-osm",
+      "source-layer": "waterareas_gen0",
+      "minzoom": 5,
+      "maxzoom": 10,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "rgba(144, 204, 203, 1)"
+      }
+    },
+    {
+      "id": "waterareas_gen0_z5",
+      "type": "fill",
+      "source": "tegola-osm",
+      "source-layer": "waterareas_gen0",
+      "minzoom": 3,
+      "maxzoom": 5,
+      "filter": [
+        "all",
+        [
+          ">",
+          "area",
+          1000000000
+        ]
+      ],
+      "layout": {
+        "visibility": "none"
+      },
+      "paint": {
+        "fill-color": "rgba(144, 204, 203, 1)"
+      }
+    },
+    {
+      "id": "roads14_trackfillcase",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_14-20",
+      "minzoom": 0,
+      "maxzoom": 24,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "track"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(239, 221, 203, 1)",
+        "line-width": {
+          "stops": [
+            [
+              14,
+              4
+            ],
+            [
+              20,
+              16
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads14_trackfill",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_14-20",
+      "minzoom": 0,
+      "maxzoom": 24,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "track"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(251, 247, 245, 1)",
+        "line-width": {
+          "stops": [
+            [
+              14,
+              1
+            ],
+            [
+              20,
+              3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads14_track",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_14-20",
+      "maxzoom": 24,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "track"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(218, 191, 164, 1)",
+        "line-dasharray": [
+          2,
+          5
+        ],
+        "line-width": 2
+      }
+    },
+    {
+      "id": "roads14_footway",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_14-20",
+      "maxzoom": 24,
+      "filter": [
+        "all",
+        [
+          "in",
+          "type",
+          "footway",
+          "cycleway"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(191, 147, 98, 1)",
+        "line-width": 1,
+        "line-dasharray": [
+          1,
+          2
+        ]
+      }
+    },
+    {
+      "id": "roads14_pier",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_14-20",
+      "maxzoom": 24,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "pier"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(255, 255, 255, 1)",
+        "line-width": 4
+      }
+    },
+    {
+      "id": "roads14_railyard",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_14-20",
+      "minzoom": 0,
+      "maxzoom": 24,
+      "filter": [
+        "any",
+        [
+          "in",
+          "type",
+          "rail",
+          "disused"
+        ],
+        [
+          "in",
+          "service",
+          "yard",
+          "siding"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(153, 153, 153, 1)",
+        "line-width": {
+          "stops": [
+            [
+              15,
+              0.35
+            ],
+            [
+              20,
+              2.25
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads14_rail",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_14-20",
+      "maxzoom": 24,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "rail"
+        ],
+        [
+          "!in",
+          "service",
+          "yard",
+          "siding"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(153, 153, 153, 1)",
+        "line-width": {
+          "stops": [
+            [
+              14,
+              1.25
+            ],
+            [
+              20,
+              2.25
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads14_residentialcase",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_14-20",
+      "minzoom": 0,
+      "maxzoom": 24,
+      "filter": [
+        "all",
+        [
+          "in",
+          "type",
+          "residential",
+          "service",
+          "unclassified",
+          "steps",
+          "living_street",
+          "raceway"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(226, 225, 221, 1)",
+        "line-width": {
+          "stops": [
+            [
+              14,
+              4
+            ],
+            [
+              18,
+              16
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads14_residential",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_14-20",
+      "maxzoom": 24,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "residential"
+        ]
+      ],
+      "paint": {
+        "line-color": "rgba(237, 236, 231, 1)",
+        "line-width": {
+          "stops": [
+            [
+              14,
+              1
+            ],
+            [
+              15,
+              1.5
+            ],
+            [
+              16,
+              1.5
+            ],
+            [
+              17,
+              2
+            ],
+            [
+              18,
+              3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads14_tertiarytunnel",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_14-20",
+      "minzoom": 0,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "tertiary"
+        ],
+        [
+          "==",
+          "tunnel",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(245, 237, 179, 1)",
+        "line-width": {
+          "stops": [
+            [
+              14,
+              3.5
+            ],
+            [
+              15,
+              4
+            ],
+            [
+              16,
+              6
+            ],
+            [
+              17,
+              8
+            ],
+            [
+              18,
+              12
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads14_tertiarycase",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_14-20",
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "tertiary"
+        ],
+        [
+          "!=",
+          "tunnel",
+          1
+        ],
+        [
+          "!=",
+          "bridge",
+          1
+        ]
+      ],
+      "paint": {
+        "line-color": "rgba(194, 186, 128, 1)",
+        "line-width": {
+          "stops": [
+            [
+              14,
+              3.5
+            ],
+            [
+              15,
+              4
+            ],
+            [
+              16,
+              6
+            ],
+            [
+              17,
+              8
+            ],
+            [
+              18,
+              12
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads14_tertiarybridge",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_14-20",
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "tertiary"
+        ],
+        [
+          "==",
+          "bridge",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(169, 161, 103, 1)",
+        "line-width": {
+          "stops": [
+            [
+              14,
+              3.5
+            ],
+            [
+              15,
+              4
+            ],
+            [
+              16,
+              6
+            ],
+            [
+              17,
+              8
+            ],
+            [
+              18,
+              12
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads14_tertiary",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_14-20",
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "tertiary"
+        ],
+        [
+          "!=",
+          "tunnel",
+          1
+        ]
+      ],
+      "paint": {
+        "line-color": "rgba(219, 211, 153, 1)",
+        "line-width": {
+          "stops": [
+            [
+              14,
+              1
+            ],
+            [
+              18,
+              3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads14_secondarytunnel",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_14-20",
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "secondary"
+        ],
+        [
+          "==",
+          "tunnel",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(255, 229, 202, 1)",
+        "line-width": {
+          "stops": [
+            [
+              14,
+              4.5
+            ],
+            [
+              15,
+              5
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              10
+            ],
+            [
+              18,
+              14
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads14_secondarycase",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_14-20",
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "secondary"
+        ],
+        [
+          "!=",
+          "tunnel",
+          1
+        ],
+        [
+          "!=",
+          "bridge",
+          1
+        ]
+      ],
+      "paint": {
+        "line-color": "rgba(208, 178, 151, 1)",
+        "line-width": {
+          "stops": [
+            [
+              14,
+              4.5
+            ],
+            [
+              15,
+              5
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              10
+            ],
+            [
+              18,
+              14
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads14_secondarybridge",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_14-20",
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "secondary"
+        ],
+        [
+          "==",
+          "bridge",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(183, 153, 126, 1)",
+        "line-width": {
+          "stops": [
+            [
+              14,
+              4.5
+            ],
+            [
+              15,
+              5
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              10
+            ],
+            [
+              18,
+              14
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads14_secondary",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_14-20",
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "secondary"
+        ],
+        [
+          "!=",
+          "tunnel",
+          1
+        ]
+      ],
+      "paint": {
+        "line-color": "rgba(233, 203, 176, 1)",
+        "line-width": {
+          "stops": [
+            [
+              14,
+              2
+            ],
+            [
+              17,
+              2
+            ],
+            [
+              18,
+              3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads14_primarytunnel",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_14-20",
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "primary"
+        ],
+        [
+          "==",
+          "tunnel",
+          1
+        ]
+      ],
+      "paint": {
+        "line-color": "rgba(236, 173, 168, 1)",
+        "line-width": {
+          "stops": [
+            [
+              14,
+              4.5
+            ],
+            [
+              15,
+              5
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              10
+            ],
+            [
+              18,
+              14
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads14_primarycase",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_14-20",
+      "maxzoom": 20,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "primary"
+        ],
+        [
+          "!=",
+          "tunnel",
+          1
+        ],
+        [
+          "!=",
+          "bridge",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt"
+      },
+      "paint": {
+        "line-color": "rgba(185, 122, 117, 1)",
+        "line-width": {
+          "stops": [
+            [
+              14,
+              4.5
+            ],
+            [
+              15,
+              5
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              10
+            ],
+            [
+              18,
+              14
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads14_primarybridge",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_14-20",
+      "maxzoom": 20,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "primary"
+        ],
+        [
+          "==",
+          "bridge",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(160, 97, 92, 1)",
+        "line-width": {
+          "stops": [
+            [
+              14,
+              4.5
+            ],
+            [
+              15,
+              5
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              10
+            ],
+            [
+              18,
+              14
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads14_primary",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_14-20",
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "primary"
+        ],
+        [
+          "!=",
+          "tunnel",
+          1
+        ]
+      ],
+      "paint": {
+        "line-color": "rgba(210, 147, 142, 1)",
+        "line-width": {
+          "stops": [
+            [
+              14,
+              2
+            ],
+            [
+              17,
+              2
+            ],
+            [
+              18,
+              3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads14_motorwaytunnel",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_14-20",
+      "minzoom": 13,
+      "maxzoom": 20,
+      "filter": [
+        "all",
+        [
+          "in",
+          "type",
+          "motorway",
+          "motorway_link",
+          "trunk",
+          "trunk_link"
+        ],
+        [
+          "==",
+          "tunnel",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible",
+        "line-cap": "butt",
+        "line-join": "miter"
+      },
+      "paint": {
+        "line-color": "rgba(186, 178, 202, 1)",
+        "line-width": {
+          "stops": [
+            [
+              14,
+              5
+            ],
+            [
+              15,
+              6
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              10
+            ],
+            [
+              18,
+              16
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads14_motorwaycase",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_14-20",
+      "minzoom": 13,
+      "maxzoom": 20,
+      "filter": [
+        "all",
+        [
+          "in",
+          "type",
+          "motorway",
+          "motorway_link",
+          "trunk",
+          "trunk_link"
+        ],
+        [
+          "!=",
+          "tunnel",
+          1
+        ],
+        [
+          "!=",
+          "bridge",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible",
+        "line-cap": "butt",
+        "line-join": "miter"
+      },
+      "paint": {
+        "line-color": "rgba(135, 127, 151, 1)",
+        "line-width": {
+          "stops": [
+            [
+              14,
+              5
+            ],
+            [
+              15,
+              6
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              10
+            ],
+            [
+              18,
+              16
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads14_motorwaybridge",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_14-20",
+      "minzoom": 13,
+      "maxzoom": 20,
+      "filter": [
+        "all",
+        [
+          "in",
+          "type",
+          "motorway",
+          "motorway_link",
+          "trunk",
+          "trunk_link"
+        ],
+        [
+          "==",
+          "bridge",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible",
+        "line-cap": "butt",
+        "line-join": "miter"
+      },
+      "paint": {
+        "line-color": "rgba(110, 102, 126, 1)",
+        "line-width": {
+          "stops": [
+            [
+              14,
+              5
+            ],
+            [
+              15,
+              6
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              10
+            ],
+            [
+              18,
+              16
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads14_motorway",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_14-20",
+      "minzoom": 13,
+      "maxzoom": 20,
+      "filter": [
+        "all",
+        [
+          "in",
+          "type",
+          "motorway",
+          "motorway_link",
+          "trunk",
+          "trunk_link"
+        ],
+        [
+          "!=",
+          "tunnel",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible",
+        "line-cap": "butt",
+        "line-join": "miter"
+      },
+      "paint": {
+        "line-color": "rgba(160, 152, 176, 1)",
+        "line-width": {
+          "stops": [
+            [
+              14,
+              2
+            ],
+            [
+              15,
+              2.5
+            ],
+            [
+              16,
+              2.5
+            ],
+            [
+              17,
+              3
+            ],
+            [
+              18,
+              4
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads13_rail",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_13",
+      "maxzoom": 24,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "rail"
+        ],
+        [
+          "!in",
+          "service",
+          "yard",
+          "siding"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(153, 153, 153, 1)",
+        "line-width": {
+          "stops": [
+            [
+              13,
+              1
+            ],
+            [
+              14,
+              1.25
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads13_residentialcase",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_13",
+      "minzoom": 0,
+      "maxzoom": 24,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "residential"
+        ]
+      ],
+      "paint": {
+        "line-color": "rgba(237, 236, 231, 1)",
+        "line-width": {
+          "stops": [
+            [
+              13,
+              2.5
+            ],
+            [
+              14,
+              2
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads13_residential",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_13",
+      "maxzoom": 24,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "residential"
+        ]
+      ],
+      "paint": {
+        "line-color": "rgba(237, 236, 231, 1)"
+      }
+    },
+    {
+      "id": "roads13_tertiarytunnel",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_13",
+      "minzoom": 0,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "tertiary"
+        ],
+        [
+          "==",
+          "tunnel",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(245, 237, 179, 1)",
+        "line-width": 3.5
+      }
+    },
+    {
+      "id": "roads13_tertiarycase",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_13",
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "tertiary"
+        ],
+        [
+          "!=",
+          "tunnel",
+          1
+        ],
+        [
+          "!=",
+          "bridge",
+          1
+        ]
+      ],
+      "paint": {
+        "line-color": "rgba(194, 186, 128, 1)",
+        "line-width": 3.5
+      }
+    },
+    {
+      "id": "roads13_tertiarybridge",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_13",
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "tertiary"
+        ],
+        [
+          "==",
+          "bridge",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(169, 161, 103, 1)",
+        "line-width": 3.5
+      }
+    },
+    {
+      "id": "roads13_tertiary",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_13",
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "tertiary"
+        ],
+        [
+          "!=",
+          "tunnel",
+          1
+        ]
+      ],
+      "paint": {
+        "line-color": "rgba(219, 211, 153, 1)"
+      }
+    },
+    {
+      "id": "roads13_secondarytunnel",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_13",
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "secondary"
+        ],
+        [
+          "==",
+          "tunnel",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(255, 229, 202, 1)",
+        "line-width": 4.5
+      }
+    },
+    {
+      "id": "roads13_secondarycase",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_13",
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "secondary"
+        ],
+        [
+          "!=",
+          "tunnel",
+          1
+        ],
+        [
+          "!=",
+          "bridge",
+          1
+        ]
+      ],
+      "paint": {
+        "line-color": "rgba(208, 178, 151, 1)",
+        "line-width": 4.5
+      }
+    },
+    {
+      "id": "roads13_secondarybridge",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_13",
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "secondary"
+        ],
+        [
+          "==",
+          "bridge",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(183, 153, 126, 1)",
+        "line-width": 4.5
+      }
+    },
+    {
+      "id": "roads13_secondary",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_13",
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "secondary"
+        ],
+        [
+          "!=",
+          "tunnel",
+          1
+        ]
+      ],
+      "paint": {
+        "line-color": "rgba(233, 203, 176, 1)",
+        "line-width": 2
+      }
+    },
+    {
+      "id": "roads13_primarytunnel",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_13",
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "primary"
+        ],
+        [
+          "==",
+          "tunnel",
+          1
+        ]
+      ],
+      "paint": {
+        "line-color": "rgba(236, 173, 168, 1)",
+        "line-width": 4.5
+      }
+    },
+    {
+      "id": "roads13_primarycase",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_13",
+      "maxzoom": 14,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "primary"
+        ],
+        [
+          "!=",
+          "tunnel",
+          1
+        ],
+        [
+          "!=",
+          "bridge",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt"
+      },
+      "paint": {
+        "line-color": "rgba(185, 122, 117, 1)",
+        "line-width": 4.5
+      }
+    },
+    {
+      "id": "roads13_primarybridge",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_13",
+      "maxzoom": 14,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "primary"
+        ],
+        [
+          "==",
+          "bridge",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(160, 97, 92, 1)",
+        "line-width": 4.5
+      }
+    },
+    {
+      "id": "roads13_primary",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_13",
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "primary"
+        ],
+        [
+          "!=",
+          "tunnel",
+          1
+        ]
+      ],
+      "paint": {
+        "line-color": "rgba(210, 147, 142, 1)",
+        "line-width": 2
+      }
+    },
+    {
+      "id": "roads13_motorwaytunnel",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_13",
+      "minzoom": 13,
+      "maxzoom": 14,
+      "filter": [
+        "all",
+        [
+          "in",
+          "type",
+          "motorway",
+          "motorway_link",
+          "trunk",
+          "trunk_link"
+        ],
+        [
+          "==",
+          "tunnel",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible",
+        "line-cap": "butt",
+        "line-join": "miter"
+      },
+      "paint": {
+        "line-color": "rgba(186, 178, 202, 1)",
+        "line-width": 5
+      }
+    },
+    {
+      "id": "roads13_motorwaycase",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_13",
+      "minzoom": 13,
+      "maxzoom": 14,
+      "filter": [
+        "all",
+        [
+          "in",
+          "type",
+          "motorway",
+          "motorway_link",
+          "trunk",
+          "trunk_link"
+        ],
+        [
+          "!=",
+          "tunnel",
+          1
+        ],
+        [
+          "!=",
+          "bridge",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible",
+        "line-cap": "butt",
+        "line-join": "miter"
+      },
+      "paint": {
+        "line-color": "rgba(135, 127, 151, 1)",
+        "line-width": 5
+      }
+    },
+    {
+      "id": "roads13_motorwaybridge",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_13",
+      "minzoom": 13,
+      "maxzoom": 14,
+      "filter": [
+        "all",
+        [
+          "in",
+          "type",
+          "motorway",
+          "motorway_link",
+          "trunk",
+          "trunk_link"
+        ],
+        [
+          "==",
+          "bridge",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible",
+        "line-cap": "butt",
+        "line-join": "miter"
+      },
+      "paint": {
+        "line-color": "rgba(110, 102, 126, 1)",
+        "line-width": 5
+      }
+    },
+    {
+      "id": "roads13_motorway",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_13",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        [
+          "in",
+          "type",
+          "motorway",
+          "motorway_link",
+          "trunk",
+          "trunk_link"
+        ],
+        [
+          "!=",
+          "tunnel",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible",
+        "line-cap": "butt",
+        "line-join": "miter"
+      },
+      "paint": {
+        "line-color": "rgba(160, 152, 176, 1)",
+        "line-width": 2
+      }
+    },
+    {
+      "id": "roads11_rail",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_11-12",
+      "minzoom": 12,
+      "maxzoom": 13,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "rail"
+        ],
+        [
+          "!in",
+          "service",
+          "yard",
+          "siding"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(153, 153, 153, 1)",
+        "line-width": 1
+      }
+    },
+    {
+      "id": "roads11_tertiarytunnel",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_11-12",
+      "minzoom": 12,
+      "maxzoom": 13,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "tertiary"
+        ],
+        [
+          "==",
+          "tunnel",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(245, 237, 179, 1)",
+        "line-width": {
+          "stops": [
+            [
+              12,
+              2
+            ],
+            [
+              13,
+              3.6
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads11_tertiarycase",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_11-12",
+      "minzoom": 12,
+      "maxzoom": 13,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "tertiary"
+        ],
+        [
+          "!=",
+          "tunnel",
+          1
+        ],
+        [
+          "!=",
+          "bridge",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(194, 186, 128, 1)",
+        "line-width": {
+          "stops": [
+            [
+              12,
+              2
+            ],
+            [
+              13,
+              3.5
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads11_tertiarybridge",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_11-12",
+      "minzoom": 12,
+      "maxzoom": 13,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "tertiary"
+        ],
+        [
+          "==",
+          "bridge",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(169, 161, 103, 1)",
+        "line-width": {
+          "stops": [
+            [
+              12,
+              2
+            ],
+            [
+              13,
+              3.5
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads11_tertiary",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_11-12",
+      "minzoom": 12,
+      "maxzoom": 13,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "tertiary"
+        ],
+        [
+          "!=",
+          "tunnel",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(219, 211, 153, 1)",
+        "line-width": 1
+      }
+    },
+    {
+      "id": "roads11_secondarytunnel",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_11-12",
+      "minzoom": 11,
+      "maxzoom": 13,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "secondary"
+        ],
+        [
+          "==",
+          "tunnel",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(255, 229, 202, 1)",
+        "line-width": {
+          "stops": [
+            [
+              11,
+              3
+            ],
+            [
+              13,
+              4.5
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads11_secondarycase",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_11-12",
+      "minzoom": 11,
+      "maxzoom": 13,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "secondary"
+        ],
+        [
+          "!=",
+          "tunnel",
+          1
+        ],
+        [
+          "!=",
+          "bridge",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(208, 178, 151, 1)",
+        "line-width": {
+          "stops": [
+            [
+              11,
+              3
+            ],
+            [
+              13,
+              4.5
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads11_secondarybridge",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_11-12",
+      "minzoom": 11,
+      "maxzoom": 13,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "secondary"
+        ],
+        [
+          "==",
+          "bridge",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(183, 153, 126, 1)",
+        "line-width": {
+          "stops": [
+            [
+              11,
+              3
+            ],
+            [
+              13,
+              4.5
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads11_secondary",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_11-12",
+      "minzoom": 11,
+      "maxzoom": 13,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "secondary"
+        ],
+        [
+          "!=",
+          "tunnel",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(233, 203, 176, 1)",
+        "line-width": {
+          "stops": [
+            [
+              11,
+              1
+            ],
+            [
+              13,
+              2
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads11_primarytunnel",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_11-12",
+      "minzoom": 11,
+      "maxzoom": 13,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "primary"
+        ],
+        [
+          "==",
+          "tunnel",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(236, 173, 168, 1)",
+        "line-width": {
+          "stops": [
+            [
+              11,
+              3
+            ],
+            [
+              13,
+              4.5
+            ]
+          ]
+        },
+        "line-offset": 0,
+        "line-blur": 0
+      }
+    },
+    {
+      "id": "roads11_primarycase",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_11-12",
+      "minzoom": 11,
+      "maxzoom": 13,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "primary"
+        ],
+        [
+          "!=",
+          "tunnel",
+          1
+        ],
+        [
+          "!=",
+          "bridge",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(185, 122, 117, 1)",
+        "line-width": {
+          "stops": [
+            [
+              11,
+              3
+            ],
+            [
+              13,
+              4.5
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads11_primarybridge",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_11-12",
+      "minzoom": 11,
+      "maxzoom": 13,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "primary"
+        ],
+        [
+          "==",
+          "bridge",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(160, 97, 92, 1)",
+        "line-width": {
+          "stops": [
+            [
+              11,
+              3
+            ],
+            [
+              13,
+              4.5
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads11_primary",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_11-12",
+      "minzoom": 11,
+      "maxzoom": 13,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "primary"
+        ],
+        [
+          "!=",
+          "tunnel",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(210, 147, 142, 1)",
+        "line-width": {
+          "stops": [
+            [
+              11,
+              1
+            ],
+            [
+              13,
+              2
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads11_motorwaytunnel",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_11-12",
+      "minzoom": 11,
+      "maxzoom": 13,
+      "filter": [
+        "all",
+        [
+          "in",
+          "type",
+          "motorway",
+          "motorway_link",
+          "trunk",
+          "trunk_link"
+        ],
+        [
+          "==",
+          "tunnel",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(186, 178, 202, 1)",
+        "line-width": {
+          "stops": [
+            [
+              11,
+              3
+            ],
+            [
+              13,
+              5
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads11_motorwaycase",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_11-12",
+      "minzoom": 11,
+      "maxzoom": 13,
+      "filter": [
+        "all",
+        [
+          "in",
+          "type",
+          "motorway",
+          "motorway_link",
+          "trunk",
+          "trunk_link"
+        ],
+        [
+          "!=",
+          "tunnel",
+          1
+        ],
+        [
+          "!=",
+          "bridge",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(135, 127, 151, 1)",
+        "line-width": {
+          "stops": [
+            [
+              11,
+              3
+            ],
+            [
+              13,
+              5
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads11_motorwaybridge-copy",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_11-12",
+      "minzoom": 11,
+      "maxzoom": 13,
+      "filter": [
+        "all",
+        [
+          "in",
+          "type",
+          "motorway",
+          "motorway_link",
+          "trunk",
+          "trunk_link"
+        ],
+        [
+          "==",
+          "bridge",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(110, 102, 126, 1)",
+        "line-width": {
+          "stops": [
+            [
+              11,
+              3
+            ],
+            [
+              13,
+              5
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roads11_motorway",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_11-12",
+      "minzoom": 11,
+      "maxzoom": 13,
+      "filter": [
+        "all",
+        [
+          "in",
+          "type",
+          "motorway",
+          "motorway_link",
+          "trunk",
+          "trunk_link"
+        ],
+        [
+          "!=",
+          "tunnel",
+          1
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(160, 152, 176, 1)",
+        "line-width": {
+          "stops": [
+            [
+              11,
+              1
+            ],
+            [
+              13,
+              2
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roadsgen1_secondary",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_gen1",
+      "minzoom": 9,
+      "maxzoom": 11,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "secondary"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(233, 203, 176, 1)",
+        "line-width": {
+          "stops": [
+            [
+              9,
+              0.6
+            ],
+            [
+              11,
+              0.8
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roadsgen1_primary",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_gen1",
+      "minzoom": 9,
+      "maxzoom": 11,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "primary"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(210, 147, 142, 1)",
+        "line-width": {
+          "stops": [
+            [
+              9,
+              0.6
+            ],
+            [
+              11,
+              0.8
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roadsgen1_links",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_gen1",
+      "minzoom": 9,
+      "maxzoom": 11,
+      "filter": [
+        "all",
+        [
+          "in",
+          "type",
+          "motorway_link"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(160, 152, 176, 1)",
+        "line-width": {
+          "stops": [
+            [
+              9,
+              0.6
+            ],
+            [
+              11,
+              0.8
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roadsgen1_motorwaytrunk",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_gen1",
+      "minzoom": 9,
+      "maxzoom": 11,
+      "filter": [
+        "all",
+        [
+          "in",
+          "type",
+          "motorway",
+          "link"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(160, 152, 176, 1)",
+        "line-width": {
+          "stops": [
+            [
+              9,
+              1.4
+            ],
+            [
+              11,
+              1.8
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roadsgen0_trunk",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_gen0",
+      "minzoom": 4,
+      "maxzoom": 9,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "trunk"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(160, 152, 176, 1)",
+        "line-width": {
+          "stops": [
+            [
+              5,
+              0.2
+            ],
+            [
+              7,
+              0.3
+            ],
+            [
+              8,
+              0.5
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "roadsgen0_motorway",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "roads_gen0",
+      "minzoom": 4,
+      "maxzoom": 9,
+      "filter": [
+        "all",
+        [
+          "==",
+          "type",
+          "motorway"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(160, 152, 176, 1)",
+        "line-width": {
+          "stops": [
+            [
+              5,
+              0.4
+            ],
+            [
+              7,
+              0.6
+            ],
+            [
+              8,
+              1
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "admin_statelines6",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "admin_states_provinces_lines_5-20",
+      "minzoom": 5,
+      "maxzoom": 20,
+      "paint": {
+        "line-width": 1,
+        "line-color": "rgba(165, 156, 155, 1)",
+        "line-dasharray": [
+          10,
+          5
+        ]
+      }
+    },
+    {
+      "id": "admin_statelines4",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "admin_states_provinces_lines_3-4",
+      "minzoom": 3,
+      "maxzoom": 5,
+      "paint": {
+        "line-width": 1,
+        "line-color": "#A59C9B",
+        "line-dasharray": [
+          10,
+          5
+        ]
+      }
+    },
+    {
+      "id": "admin_boundaries6",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "admin_boundaries_5-6",
+      "minzoom": 5,
+      "maxzoom": 7,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(83, 112, 118, 1)"
+      }
+    },
+    {
+      "id": "admin_boundariesdisputed4",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "admin_boundaries_disputed_3-4",
+      "minzoom": 3,
+      "maxzoom": 5,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(83, 112, 118, 1)",
+        "line-dasharray": [
+          4,
+          1
+        ],
+        "line-width": 1
+      }
+    },
+    {
+      "id": "admin_boundaries4",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "admin_boundaries_3-4",
+      "minzoom": 3,
+      "maxzoom": 5,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(83, 112, 118, 1)"
+      }
+    },
+    {
+      "id": "admin_boundaries2",
+      "type": "line",
+      "source": "tegola-osm",
+      "source-layer": "admin_boundaries_0-2",
+      "minzoom": 0,
+      "maxzoom": 3,
+      "paint": {
+        "line-color": "rgba(83, 112, 118, 1)"
+      }
+    },
+    {
+      "id": "roadlabels_most",
+      "type": "symbol",
+      "source": "tegola-osm",
+      "source-layer": "roads_14-20",
+      "minzoom": 0,
+      "filter": [
+        "all"
+      ],
+      "layout": {
+        "text-field": "{name}",
+        "symbol-placement": "line",
+        "symbol-spacing": 250,
+        "symbol-avoid-edges": false,
+        "text-size": {
+          "stops": [
+            [
+              13,
+              10
+            ],
+            [
+              20,
+              18
+            ]
+          ]
+        },
+        "text-padding": 2,
+        "text-allow-overlap": false,
+        "text-pitch-alignment": "auto",
+        "text-rotation-alignment": "auto"
+      },
+      "paint": {
+        "text-color": "rgba(82, 82, 82, 1)",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255, 255, 255, 0.8)"
+      }
+    },
+    {
+      "id": "roadlabels_some2",
+      "type": "symbol",
+      "source": "tegola-osm",
+      "source-layer": "roads_13",
+      "filter": [
+        "all",
+        [
+          "in",
+          "type",
+          "motorway",
+          "trunk"
+        ]
+      ],
+      "layout": {
+        "text-field": "{name}",
+        "symbol-placement": "line",
+        "symbol-spacing": 250,
+        "symbol-avoid-edges": false,
+        "text-size": 10,
+        "text-padding": 2,
+        "text-allow-overlap": false,
+        "text-pitch-alignment": "auto",
+        "text-rotation-alignment": "auto"
+      },
+      "paint": {
+        "text-color": "rgba(82, 82, 82, 1)",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255, 255, 255, 0.8)"
+      }
+    },
+    {
+      "id": "roadlabels_some",
+      "type": "symbol",
+      "source": "tegola-osm",
+      "source-layer": "roads_11-12",
+      "filter": [
+        "all",
+        [
+          "in",
+          "type",
+          "motorway",
+          "trunk"
+        ]
+      ],
+      "layout": {
+        "text-field": "{name}",
+        "symbol-placement": "line",
+        "symbol-spacing": 250,
+        "symbol-avoid-edges": false,
+        "text-size": 10,
+        "text-padding": 2,
+        "text-allow-overlap": false,
+        "text-pitch-alignment": "auto",
+        "text-rotation-alignment": "auto"
+      },
+      "paint": {
+        "text-color": "rgba(82, 82, 82, 1)",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255, 255, 255, 0.8)"
+      }
+    },
+    {
+      "id": "waterareaslabels_bigest",
+      "type": "symbol",
+      "source": "tegola-osm",
+      "source-layer": "waterareas_gen1",
+      "minzoom": 8,
+      "maxzoom": 24,
+      "filter": [
+        "all",
+        [
+          ">",
+          "area",
+          10000000
+        ]
+      ],
+      "layout": {
+        "text-field": "{name}",
+        "text-font": [
+          "Open Sans Italic",
+          "Arial Unicode MS Regular"
+        ],
+        "text-padding": 2,
+        "text-allow-overlap": false,
+        "text-size": {
+          "stops": [
+            [
+              15,
+              11
+            ],
+            [
+              20,
+              20
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-color": "rgba(68, 136, 136, 1)",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(178, 220, 220, 1)"
+      }
+    },
+    {
+      "id": "waterareaslabels_big",
+      "type": "symbol",
+      "source": "tegola-osm",
+      "source-layer": "waterareas",
+      "minzoom": 12,
+      "maxzoom": 24,
+      "filter": [
+        "all",
+        [
+          ">",
+          "area",
+          100000000
+        ]
+      ],
+      "layout": {
+        "text-field": "{name}",
+        "text-font": [
+          "Open Sans Italic",
+          "Arial Unicode MS Regular"
+        ],
+        "text-padding": 2,
+        "text-allow-overlap": false,
+        "text-size": {
+          "stops": [
+            [
+              15,
+              11
+            ],
+            [
+              20,
+              20
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-color": "rgba(68, 136, 136, 1)",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(178, 220, 220, 1)"
+      }
+    },
+    {
+      "id": "waterareaslabels_small",
+      "type": "symbol",
+      "source": "tegola-osm",
+      "source-layer": "waterareas",
+      "minzoom": 15,
+      "maxzoom": 24,
+      "filter": [
+        "all",
+        [
+          ">",
+          "area",
+          100000
+        ]
+      ],
+      "layout": {
+        "text-field": "{name}",
+        "text-font": [
+          "Open Sans Italic",
+          "Arial Unicode MS Regular"
+        ],
+        "text-padding": 2,
+        "text-allow-overlap": false,
+        "text-size": {
+          "stops": [
+            [
+              15,
+              11
+            ],
+            [
+              20,
+              20
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-color": "rgba(68, 136, 136, 1)",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(178, 220, 220, 1)"
+      }
+    },
+    {
+      "id": "waterwaysabels_gen1",
+      "type": "symbol",
+      "source": "tegola-osm",
+      "source-layer": "waterways_gen1",
+      "layout": {
+        "text-field": "{name}",
+        "text-font": [
+          "Open Sans Italic",
+          "Arial Unicode MS Regular"
+        ],
+        "symbol-placement": "line",
+        "text-pitch-alignment": "auto",
+        "text-rotation-alignment": "auto",
+        "text-size": 11,
+        "symbol-spacing": 500,
+        "text-anchor": "bottom"
+      },
+      "paint": {
+        "text-color": "rgba(68, 136, 136, 1)",
+        "text-halo-color": "rgba(178, 220, 220, 1)",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "waterwayslabels",
+      "type": "symbol",
+      "source": "tegola-osm",
+      "source-layer": "waterways",
+      "layout": {
+        "text-field": "{name}",
+        "text-font": [
+          "Open Sans Italic",
+          "Arial Unicode MS Regular"
+        ],
+        "symbol-placement": "line",
+        "text-pitch-alignment": "auto",
+        "text-rotation-alignment": "auto",
+        "text-anchor": "bottom",
+        "text-size": 13,
+        "symbol-spacing": 500
+      },
+      "paint": {
+        "text-color": "rgba(68, 136, 136, 1)",
+        "text-halo-color": "rgba(178, 220, 220, 1)",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "buildings_tilt_na",
+      "type": "fill-extrusion",
+      "source": "tegola-osm",
+      "source-layer": "buildings",
+      "filter": [
+        "all",
+        [
+          "!has",
+          "height"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-extrusion-color": {
+          "property": "type",
+          "type": "categorical",
+          "stops": [
+            [
+              "",
+              "rgba(220, 215, 215, 1)"
+            ],
+            [
+              "school",
+              "rgba(249, 233, 222, 1)"
+            ],
+            [
+              "university",
+              "rgba(249, 233, 222, 1)"
+            ],
+            [
+              "college",
+              "rgba(249, 233, 222, 1)"
+            ],
+            [
+              "hospital",
+              "rgba(229, 198, 195, 1)"
+            ]
+          ]
+        },
+        "fill-extrusion-height": 5,
+        "fill-extrusion-base": 0
+      }
+    },
+    {
+      "id": "buildings_tilt",
+      "type": "fill-extrusion",
+      "source": "tegola-osm",
+      "source-layer": "buildings",
+      "filter": [
+        "all",
+        [
+          "has",
+          "height"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-extrusion-color": {
+          "property": "type",
+          "type": "categorical",
+          "stops": [
+            [
+              "",
+              "rgba(220, 215, 215, 1)"
+            ],
+            [
+              "school",
+              "rgba(249, 233, 222, 1)"
+            ],
+            [
+              "university",
+              "rgba(249, 233, 222, 1)"
+            ],
+            [
+              "college",
+              "rgba(249, 233, 222, 1)"
+            ],
+            [
+              "hospital",
+              "rgba(229, 198, 195, 1)"
+            ]
+          ]
+        },
+        "fill-extrusion-height": {
+          "property": "height",
+          "type": "identity"
+        },
+        "fill-extrusion-base": 0
+      }
+    },
+    {
+      "id": "landusageslabels_park",
+      "type": "symbol",
+      "source": "tegola-osm",
+      "source-layer": "landusages",
+      "minzoom": 14,
+      "maxzoom": 24,
+      "filter": [
+        "all",
+        [
+          "in",
+          "type",
+          "park",
+          "sports_centre",
+          "stadium",
+          "grass",
+          "grassland",
+          "garden",
+          "village_green",
+          "recreation_ground",
+          "picnic_site",
+          "camp_site",
+          "playground"
+        ],
+        [
+          ">",
+          "area",
+          12000
+        ]
+      ],
+      "layout": {
+        "text-field": "{name}",
+        "text-size": 11
+      },
+      "paint": {
+        "text-color": "rgba(122, 143, 61, 1)",
+        "text-halo-color": "rgba(228, 235, 209, 1)",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "landusageslabels_forest",
+      "type": "symbol",
+      "source": "tegola-osm",
+      "source-layer": "landusages",
+      "minzoom": 14,
+      "maxzoom": 24,
+      "filter": [
+        "all",
+        [
+          "in",
+          "type",
+          "forest",
+          "wood",
+          "nature_reserve"
+        ]
+      ],
+      "layout": {
+        "text-field": "{name}",
+        "text-size": 11
+      },
+      "paint": {
+        "text-color": "rgba(95, 107, 71, 1)",
+        "text-halo-color": "rgba(201, 213, 190, 1)",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "landusageslabels_school",
+      "type": "symbol",
+      "source": "tegola-osm",
+      "source-layer": "landusages",
+      "minzoom": 14,
+      "maxzoom": 24,
+      "filter": [
+        "all",
+        [
+          "in",
+          "type",
+          "college",
+          "school",
+          "education",
+          "university",
+          ""
+        ]
+      ],
+      "layout": {
+        "text-field": "{name}",
+        "text-size": 11
+      },
+      "paint": {
+        "text-color": "rgba(176, 130, 130, 1)",
+        "text-halo-color": "rgba(245, 239, 239, 1)",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "state_labels",
+      "type": "symbol",
+      "source": "tegola-osm",
+      "source-layer": "admin_label_points_5-20",
+      "minzoom": 5,
+      "maxzoom": 11,
+      "filter": [
+        "all",
+        [
+          "==",
+          "adm0_sr",
+          1
+        ]
+      ],
+      "layout": {
+        "text-font": [
+          "Open Sans Bold Italic",
+          "Arial Unicode MS Regular"
+        ],
+        "text-field": "{name}",
+        "text-size": {
+          "stops": [
+            [
+              5,
+              9
+            ],
+            [
+              7,
+              11
+            ],
+            [
+              9,
+              12
+            ],
+            [
+              13,
+              14
+            ]
+          ]
+        }
+      },
+      "paint": {
+        "text-color": "rgba(166, 166, 170, 1)",
+        "text-halo-color": "rgba(255, 255, 255, 0.35)",
+        "text-halo-width": 2,
+        "text-halo-blur": 0
+      }
+    },
+    {
+      "id": "country_labels",
+      "type": "symbol",
+      "source": "tegola-osm",
+      "source-layer": "admin_label_points_3-20",
+      "minzoom": 3,
+      "maxzoom": 8,
+      "filter": [
+        "all",
+        [
+          "==",
+          "scalerank",
+          0
+        ]
+      ],
+      "layout": {
+        "text-font": [
+          "Open Sans Bold",
+          "Arial Unicode MS Regular"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              3,
+              9
+            ],
+            [
+              8,
+              14
+            ]
+          ]
+        },
+        "text-max-width": {
+          "stops": [
+            [
+              3,
+              40
+            ],
+            [
+              8,
+              80
+            ]
+          ]
+        },
+        "text-letter-spacing": {
+          "stops": [
+            [
+              3,
+              0
+            ],
+            [
+              7,
+              1
+            ],
+            [
+              8,
+              1
+            ]
+          ]
+        },
+        "text-field": "{name}"
+      },
+      "paint": {
+        "text-color": "rgba(68, 51, 85, 1)",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255, 255, 255, 1)",
+        "text-halo-blur": 38
+      }
+    }
+  ],
+  "id": "ciwf4zbsv007y2pmt2rspc1dc",
+  "owner": ""
+}

--- a/docs/openlayers/js/olms.js
+++ b/docs/openlayers/js/olms.js
@@ -1,0 +1,2204 @@
+(function(_g){(function(f){var r=(typeof require==='function'?require:function(name){return {"_":null,"ol/observable":ol.Observable,"ol/proj":ol.proj,"ol/tilegrid":ol.tilegrid,"ol/map":ol.Map,"ol/format/geojson":ol.format.GeoJSON,"ol/format/mvt":ol.format.MVT,"ol/layer/tile":ol.layer.Tile,"ol/layer/vector":ol.layer.Vector,"ol/layer/vectortile":ol.layer.VectorTile,"ol/source/tilejson":ol.source.TileJSON,"ol/source/vector":ol.source.Vector,"ol/source/xyz":ol.source.XYZ,"ol/source/vectortile":ol.source.VectorTile,"ol/style/style":ol.style.Style,"ol/style/fill":ol.style.Fill,"ol/style/stroke":ol.style.Stroke,"ol/style/circle":ol.style.Circle,"ol/style/icon":ol.style.Icon,"ol/style/text":ol.style.Text}[name];});if (typeof exports==='object'&&typeof module!=='undefined'){module.exports=f(r)}else if(typeof define==='function'&&define.amd){define(["_","ol/observable","ol/proj","ol/tilegrid","ol/map","ol/format/geojson","ol/format/mvt","ol/layer/tile","ol/layer/vector","ol/layer/vectortile","ol/source/tilejson","ol/source/vector","ol/source/xyz","ol/source/vectortile","ol/style/style","ol/style/fill","ol/style/stroke","ol/style/circle","ol/style/icon","ol/style/text"],f.bind(_g,r))}else{f(r)}})(function(require,define,module,exports){var _m=(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; /*
+                                                                                                                                                                                                                                                                              ol-mapbox-style - Use Mapbox Style objects with OpenLayers
+                                                                                                                                                                                                                                                                              Copyright 2016-present Boundless Spatial, Inc.
+                                                                                                                                                                                                                                                                              License: https://raw.githubusercontent.com/boundlessgeo/ol-mapbox-gl-style/master/LICENSE.md
+                                                                                                                                                                                                                                                                              */
+
+exports.applyStyle = applyStyle;
+exports.applyBackground = applyBackground;
+exports.apply = apply;
+
+var _function = require('@mapbox/mapbox-gl-style-spec/function');
+
+var _function2 = _interopRequireDefault(_function);
+
+var _mapboxToCssFont = require('mapbox-to-css-font');
+
+var _mapboxToCssFont2 = _interopRequireDefault(_mapboxToCssFont);
+
+var _mapboxToOlStyle = require('mapbox-to-ol-style');
+
+var _mapboxToOlStyle2 = _interopRequireDefault(_mapboxToOlStyle);
+
+var _webfontloader = require('webfontloader');
+
+var _webfontloader2 = _interopRequireDefault(_webfontloader);
+
+var _proj = require('ol/proj');
+
+var _proj2 = _interopRequireDefault(_proj);
+
+var _tilegrid = require('ol/tilegrid');
+
+var _tilegrid2 = _interopRequireDefault(_tilegrid);
+
+var _map = require('ol/map');
+
+var _map2 = _interopRequireDefault(_map);
+
+var _geojson = require('ol/format/geojson');
+
+var _geojson2 = _interopRequireDefault(_geojson);
+
+var _mvt = require('ol/format/mvt');
+
+var _mvt2 = _interopRequireDefault(_mvt);
+
+var _observable = require('ol/observable');
+
+var _observable2 = _interopRequireDefault(_observable);
+
+var _tile = require('ol/layer/tile');
+
+var _tile2 = _interopRequireDefault(_tile);
+
+var _vector = require('ol/layer/vector');
+
+var _vector2 = _interopRequireDefault(_vector);
+
+var _vectortile = require('ol/layer/vectortile');
+
+var _vectortile2 = _interopRequireDefault(_vectortile);
+
+var _tilejson = require('ol/source/tilejson');
+
+var _tilejson2 = _interopRequireDefault(_tilejson);
+
+var _vector3 = require('ol/source/vector');
+
+var _vector4 = _interopRequireDefault(_vector3);
+
+var _vectortile3 = require('ol/source/vectortile');
+
+var _vectortile4 = _interopRequireDefault(_vectortile3);
+
+var _xyz = require('ol/source/xyz');
+
+var _xyz2 = _interopRequireDefault(_xyz);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var availableFonts;
+
+function loadFont(fonts, onChange) {
+  if (!Array.isArray(fonts)) {
+    var stops = fonts.stops;
+    if (stops) {
+      for (var i = 0, ii = stops.length; i < ii; ++i) {
+        loadFont(stops[i][1], onChange);
+      }
+    }
+    return;
+  }
+  var families = fonts.map(function (font) {
+    return (0, _mapboxToCssFont2.default)(font, 1).split(' 1px ')[1];
+  });
+  _webfontloader2.default.load({
+    google: {
+      families: families
+    },
+    fontactive: function fontactive(family) {
+      var index = families.indexOf(family);
+      if (index > -1) {
+        var font = families[index];
+        if (!availableFonts) {
+          availableFonts = [];
+        }
+        if (availableFonts.indexOf(font) == -1) {
+          availableFonts.push(families[index]);
+          onChange();
+        }
+      }
+    },
+    inactive: function inactive() {
+      onChange();
+    },
+    timeout: 1500
+  });
+}
+
+var defaultFont = ['Open Sans Regular', 'Arial Unicode MS Regular'];
+
+function preprocess(layer, onChange) {
+  if ('layout' in layer && 'text-field' in layer.layout) {
+    loadFont(layer.layout['text-font'] || defaultFont, onChange);
+  }
+}
+
+var spriteRegEx = /^(.*)(\?.*)$/;
+
+function withPath(url, path) {
+  if (path && url.indexOf('http') != 0) {
+    url = path + url;
+  }
+  return url;
+}
+
+function toSpriteUrl(url, path, extension) {
+  url = withPath(url, path);
+  var parts = url.match(spriteRegEx);
+  return parts ? parts[1] + extension + (parts.length > 2 ? parts[2] : '') : url + extension;
+}
+
+/**
+ * Applies a style function to an `ol.layer.VectorTile` or `ol.layer.Vector`
+ * with an `ol.source.VectorTile` or an `ol.source.Vector`. The style function
+ * will render all layers from the `glStyle` object that use the specified
+ * `source`, or a subset of layers from the same source. The source needs to be
+ * a `"type": "vector"`, `"type": "geojson"` or `"type": "raster"` source.
+ *
+ * @param {ol.layer.VectorTile} layer OpenLayers layer.
+ * @param {string|Object} glStyle Mapbox Style object.
+ * @param {string} source `source` key or an array of layer `id`s from the
+ * Mapbox Style object. When a `source` key is provided, all layers for the
+ * specified source will be included in the style function. When layer `id`s
+ * are provided, they must be from layers that use the same source.
+ * @param {string} [path=undefined] Path of the style file. Only required when
+ * a relative path is used with the `"sprite"` property of the style.
+ * @return {Promise} Promise which will be resolved when the style can be used
+ * for rendering.
+ */
+function applyStyle(layer, glStyle, source, path) {
+  return new Promise(function (resolve, reject) {
+
+    if ((typeof glStyle === 'undefined' ? 'undefined' : _typeof(glStyle)) != 'object') {
+      glStyle = JSON.parse(glStyle);
+    }
+    if (glStyle.version != 8) {
+      reject(new Error('glStyle version 8 required.'));
+    }
+    var spriteData;
+    var spriteImageUrl;
+    var spriteScale;
+    if (glStyle.sprite) {
+      spriteScale = window.devicePixelRatio >= 1.5 ? 0.5 : 1;
+      var xhr = new window.XMLHttpRequest();
+      var sizeFactor = spriteScale == 0.5 ? '@2x' : '';
+      var spriteUrl = toSpriteUrl(glStyle.sprite, path, sizeFactor + '.json');
+      xhr.open('GET', spriteUrl);
+      xhr.onload = xhr.onerror = function () {
+        if (!xhr.responseText) {
+          reject(new Error('Sprites cannot be loaded from ' + spriteUrl));
+        }
+        spriteData = JSON.parse(xhr.responseText);
+        onChange();
+      };
+      xhr.send();
+      spriteImageUrl = toSpriteUrl(glStyle.sprite, path, sizeFactor + '.png');
+      var spriteImage = document.createElement('IMG');
+      spriteImage.onload = function () {
+        onChange();
+      };
+      spriteImage.src = spriteImageUrl;
+    }
+
+    var resolutions;
+    if (layer instanceof _vectortile2.default) {
+      resolutions = layer.getSource().getTileGrid().getResolutions();
+    }
+    var style;
+    function onChange() {
+      if (!style && (!glStyle.sprite || spriteData) && (!availableFonts || availableFonts.length > 0)) {
+        style = (0, _mapboxToOlStyle2.default)(glStyle, source, resolutions, spriteData, spriteImageUrl, availableFonts);
+        layer.setStyle(style);
+        resolve();
+      } else if (style) {
+        layer.setStyle(style);
+      }
+    }
+    if (layer instanceof _vectortile2.default || layer instanceof _vector2.default) {
+      try {
+        var layers = glStyle.layers;
+        for (var i = 0, ii = layers.length; i < ii; ++i) {
+          if (typeof source == 'string' && layers[i].source == source || source.indexOf(layers[i].id) >= 0) {
+            preprocess(layers[i], onChange);
+          }
+        }
+        onChange();
+      } catch (e) {
+        window.setTimeout(function () {
+          reject(e);
+        }, 0);
+      }
+    }
+  });
+}
+
+function setBackground(map, layer) {
+  function updateStyle() {
+    var layout = layer.layout || {};
+    var paint = layer.paint || {};
+    var element = map.getTargetElement();
+    var zoom = map.getView().getZoom();
+    if ('background-color' in paint) {
+      element.style.backgroundColor = (0, _function2.default)(paint['background-color'], { function: 'piecewise-constant' })(zoom);
+    }
+    if ('background-opacity' in paint) {
+      element.style.backgroundOpacity = (0, _function2.default)(paint['background-opacity'], { function: 'interpolated' })(zoom);
+    }
+    if (layout.visibility == 'none') {
+      element.style.backgroundColor = '';
+      element.style.backgroundOpacity = '';
+    }
+  }
+  if (map.getTargetElement()) {
+    updateStyle();
+  }
+  map.on(['change:resolution', 'change:target'], updateStyle);
+}
+
+/**
+ * Applies properties of the Mapbox Style's first `background` layer to the map.
+ * @param {ol.Map} map OpenLayers Map.
+ * @param {Object} glStyle Mapbox Style object.
+ */
+function applyBackground(map, glStyle) {
+  glStyle.layers.some(function (l) {
+    if (l.type == 'background') {
+      setBackground(map, l);
+      return true;
+    }
+  });
+}
+
+function getSourceIdByRef(layers, ref) {
+  var sourceId;
+  layers.some(function (layer) {
+    if (layer.id == ref) {
+      sourceId = layer.source;
+      return true;
+    }
+  });
+  return sourceId;
+}
+
+function processStyle(glStyle, map, baseUrl, path, accessToken) {
+  var view = map.getView();
+  if ('center' in glStyle && !view.getCenter()) {
+    view.setCenter(_proj2.default.fromLonLat(glStyle.center));
+  }
+  if ('zoom' in glStyle && view.getZoom() == undefined) {
+    view.setZoom(glStyle.zoom);
+  }
+  if (!('zoom' in glStyle || 'center' in glStyle)) {
+    view.fit(view.getProjection().getExtent(), {
+      nearest: true,
+      size: map.getSize()
+    });
+  }
+  if (glStyle.sprite && glStyle.sprite.indexOf('mapbox://') == 0) {
+    glStyle.sprite = baseUrl + '/sprite' + accessToken;
+  }
+
+  var glLayers = glStyle.layers;
+  var geoJsonFormat = new _geojson2.default();
+  var layerIds = [];
+
+  function finalizeLayer(layer) {
+    if (layerIds.length > 0) {
+      map.addLayer(layer);
+      var setStyle = function setStyle() {
+        applyStyle(layer, glStyle, layerIds, path).then(function () {
+          layer.setVisible(true);
+        }, function (e) {
+          /*eslint no-console: ["error", { allow: ["error"] }] */
+          console.error(e);
+        });
+      };
+      if (layer.getSource()) {
+        setStyle();
+      } else {
+        layer.once('change:source', setStyle);
+      }
+    }
+  }
+
+  var glLayer, glSource, glSourceId, id, layer, mapid, url;
+  for (var i = 0, ii = glLayers.length; i < ii; ++i) {
+    glLayer = glLayers[i];
+    if (glLayer.type == 'background') {
+      setBackground(map, glLayer);
+    } else {
+      id = glLayer.source || getSourceIdByRef(glLayers, glLayer.ref);
+      if (id != glSourceId) {
+        finalizeLayer(layer);
+        layerIds = [];
+        glSource = glStyle.sources[id];
+        url = glSource.url;
+        var tiles = glSource.tiles;
+        if (url) {
+          if (url.indexOf('mapbox://') == 0) {
+            mapid = url.replace('mapbox://', '');
+            tiles = ['a', 'b', 'c', 'd'].map(function (host) {
+              return 'https://' + host + '.tiles.mapbox.com/v4/' + mapid + '/{z}/{x}/{y}.' + (glSource.type == 'vector' ? 'vector.pbf' : 'png') + accessToken;
+            });
+          }
+        }
+
+        if (glSource.type == 'vector') {
+          layer = tiles ? new _vectortile2.default({
+            source: new _vectortile4.default({
+              attributions: glSource.attribution,
+              format: new _mvt2.default(),
+              tileGrid: _tilegrid2.default.createXYZ({
+                tileSize: 512,
+                maxZoom: 'maxzoom' in glSource ? glSource.maxzoom : 22,
+                minZoom: glSource.minzoom
+              }),
+              tilePixelRatio: 8,
+              urls: tiles
+            }),
+            visible: false,
+            zIndex: i
+          }) : function () {
+            var layer = new _vectortile2.default({
+              visible: false,
+              zIndex: i
+            });
+            var tilejson = new _tilejson2.default({
+              url: url
+            });
+            var key = tilejson.on('change', function () {
+              if (tilejson.getState() == 'ready') {
+                layer.setSource(new _vectortile4.default({
+                  attributions: tilejson.getAttributions(),
+                  format: new _mvt2.default(),
+                  tileGrid: tilejson.getTileGrid(),
+                  tilePixelRatio: 16,
+                  tileUrlFunction: tilejson.getTileUrlFunction()
+                }));
+                _observable2.default.unByKey(key);
+              }
+            });
+            return layer;
+          }();
+        } else if (glSource.type == 'raster') {
+          var source;
+          if (!glSource.tiles) {
+            source = function () {
+              return new _tilejson2.default({
+                url: url,
+                crossOrigin: 'anonymous'
+              });
+            }();
+          } else {
+            source = new _xyz2.default({
+              attributions: glSource.attribution,
+              minZoom: glSource.minzoom,
+              maxZoom: 'maxzoom' in glSource ? glSource.maxzoom : 22,
+              tileSize: glSource.tileSize || 512,
+              url: url,
+              urls: glSource.tiles,
+              crossOrigin: 'anonymous'
+            });
+          }
+          source.setTileLoadFunction(function (tile, src) {
+            if (src.indexOf('{bbox-epsg-3857}') != -1) {
+              var bbox = source.getTileGrid().getTileCoordExtent(tile.getTileCoord());
+              src = src.replace('{bbox-epsg-3857}', bbox.toString());
+            }
+            tile.getImage().src = src;
+          });
+          layer = new _tile2.default({
+            source: source
+          });
+        } else if (glSource.type == 'geojson') {
+          var data = glSource.data;
+          var features, geoJsonUrl;
+          if (typeof data == 'string') {
+            geoJsonUrl = withPath(data, path);
+          } else {
+            features = geoJsonFormat.readFeatures(data, { featureProjection: 'EPSG:3857' });
+          }
+          layer = new _vector2.default({
+            source: new _vector4.default({
+              attributions: glSource.attribution,
+              features: features,
+              format: geoJsonFormat,
+              url: geoJsonUrl
+            }),
+            visible: false,
+            zIndex: i
+          });
+        }
+        glSourceId = id;
+      }
+      layerIds.push(glLayer.id);
+    }
+  }
+  finalizeLayer(layer);
+}
+
+/**
+ * Loads and applies a Mapbox Style object to an OpenLayers Map.
+ * @param {ol.Map|HTMLElement|stribng} map Either an existing OpenLayers Map
+ * instance, or a HTML element, or the id of a HTML element that will be the
+ * target of a new OpenLayers Map.
+ * @param {string} style Url pointing to a Mapbox Style object. When using
+ * Mapbox APIs, the url must contain an access token and look like
+ * `https://api.mapbox.com/styles/v1/mapbox/bright-v9?access_token=[your_access_token_here]`.
+ * @return {ol.Map} The OpenLayers Map instance that will be populated with the
+ * contents described in the Mapbox Style object.
+ */
+function apply(map, style) {
+
+  var accessToken, baseUrl, path;
+
+  if (!(map instanceof _map2.default)) {
+    map = new _map2.default({
+      target: map
+    });
+  }
+
+  var parts = style.match(spriteRegEx);
+  if (parts) {
+    baseUrl = parts[1];
+    accessToken = parts.length > 2 ? parts[2] : '';
+  }
+  var xhr = new XMLHttpRequest();
+  xhr.open('GET', style);
+  var a = document.createElement('A');
+  a.href = style;
+  path = a.pathname.split('/').slice(0, -1).join('/') + '/';
+  xhr.addEventListener('load', function () {
+    var glStyle = JSON.parse(xhr.responseText);
+    processStyle(glStyle, map, baseUrl, path, accessToken);
+  });
+  xhr.addEventListener('error', function () {
+    throw new Error('Could not load ' + style);
+  });
+  xhr.send();
+
+  return map;
+}
+
+},{"@mapbox/mapbox-gl-style-spec/function":4,"mapbox-to-css-font":9,"mapbox-to-ol-style":10,"ol/format/geojson":"ol/format/geojson","ol/format/mvt":"ol/format/mvt","ol/layer/tile":"ol/layer/tile","ol/layer/vector":"ol/layer/vector","ol/layer/vectortile":"ol/layer/vectortile","ol/map":"ol/map","ol/observable":"ol/observable","ol/proj":"ol/proj","ol/source/tilejson":"ol/source/tilejson","ol/source/vector":"ol/source/vector","ol/source/vectortile":"ol/source/vectortile","ol/source/xyz":"ol/source/xyz","ol/tilegrid":"ol/tilegrid","webfontloader":11}],2:[function(require,module,exports){
+'use strict';
+
+module.exports = createFilter;
+
+var types = ['Unknown', 'Point', 'LineString', 'Polygon'];
+
+/**
+ * Given a filter expressed as nested arrays, return a new function
+ * that evaluates whether a given feature (with a .properties or .tags property)
+ * passes its test.
+ *
+ * @private
+ * @param {Array} filter mapbox gl filter
+ * @returns {Function} filter-evaluating function
+ */
+function createFilter(filter) {
+    return new Function('f', 'var p = (f && f.properties || {}); return ' + compile(filter));
+}
+
+function compile(filter) {
+    if (!filter) return 'true';
+    var op = filter[0];
+    if (filter.length <= 1) return op === 'any' ? 'false' : 'true';
+    var str = op === '==' ? compileComparisonOp(filter[1], filter[2], '===', false) : op === '!=' ? compileComparisonOp(filter[1], filter[2], '!==', false) : op === '<' || op === '>' || op === '<=' || op === '>=' ? compileComparisonOp(filter[1], filter[2], op, true) : op === 'any' ? compileLogicalOp(filter.slice(1), '||') : op === 'all' ? compileLogicalOp(filter.slice(1), '&&') : op === 'none' ? compileNegation(compileLogicalOp(filter.slice(1), '||')) : op === 'in' ? compileInOp(filter[1], filter.slice(2)) : op === '!in' ? compileNegation(compileInOp(filter[1], filter.slice(2))) : op === 'has' ? compileHasOp(filter[1]) : op === '!has' ? compileNegation(compileHasOp(filter[1])) : 'true';
+    return '(' + str + ')';
+}
+
+function compilePropertyReference(property) {
+    return property === '$type' ? 'f.type' : property === '$id' ? 'f.id' : 'p[' + JSON.stringify(property) + ']';
+}
+
+function compileComparisonOp(property, value, op, checkType) {
+    var left = compilePropertyReference(property);
+    var right = property === '$type' ? types.indexOf(value) : JSON.stringify(value);
+    return (checkType ? 'typeof ' + left + '=== typeof ' + right + '&&' : '') + left + op + right;
+}
+
+function compileLogicalOp(expressions, op) {
+    return expressions.map(compile).join(op);
+}
+
+function compileInOp(property, values) {
+    if (property === '$type') values = values.map(function (value) {
+        return types.indexOf(value);
+    });
+    var left = JSON.stringify(values.sort(compare));
+    var right = compilePropertyReference(property);
+
+    if (values.length <= 200) return left + '.indexOf(' + right + ') !== -1';
+
+    return '' + ('function(v, a, i, j) {' + 'while (i <= j) { var m = (i + j) >> 1;' + '    if (a[m] === v) return true; if (a[m] > v) j = m - 1; else i = m + 1;' + '}' + 'return false; }(') + right + ', ' + left + ',0,' + (values.length - 1) + ')';
+}
+
+function compileHasOp(property) {
+    return property === '$id' ? '"id" in f' : JSON.stringify(property) + ' in p';
+}
+
+function compileNegation(expression) {
+    return '!(' + expression + ')';
+}
+
+// Comparison function to sort numbers and strings
+function compare(a, b) {
+    return a < b ? -1 : a > b ? 1 : 0;
+}
+
+},{}],3:[function(require,module,exports){
+'use strict';
+
+// Constants
+
+var Xn = 0.950470,
+    // D65 standard referent
+Yn = 1,
+    Zn = 1.088830,
+    t0 = 4 / 29,
+    t1 = 6 / 29,
+    t2 = 3 * t1 * t1,
+    t3 = t1 * t1 * t1,
+    deg2rad = Math.PI / 180,
+    rad2deg = 180 / Math.PI;
+
+// Utilities
+function xyz2lab(t) {
+    return t > t3 ? Math.pow(t, 1 / 3) : t / t2 + t0;
+}
+
+function lab2xyz(t) {
+    return t > t1 ? t * t * t : t2 * (t - t0);
+}
+
+function xyz2rgb(x) {
+    return 255 * (x <= 0.0031308 ? 12.92 * x : 1.055 * Math.pow(x, 1 / 2.4) - 0.055);
+}
+
+function rgb2xyz(x) {
+    x /= 255;
+    return x <= 0.04045 ? x / 12.92 : Math.pow((x + 0.055) / 1.055, 2.4);
+}
+
+// LAB
+function rgbToLab(rgbColor) {
+    var b = rgb2xyz(rgbColor[0]),
+        a = rgb2xyz(rgbColor[1]),
+        l = rgb2xyz(rgbColor[2]),
+        x = xyz2lab((0.4124564 * b + 0.3575761 * a + 0.1804375 * l) / Xn),
+        y = xyz2lab((0.2126729 * b + 0.7151522 * a + 0.0721750 * l) / Yn),
+        z = xyz2lab((0.0193339 * b + 0.1191920 * a + 0.9503041 * l) / Zn);
+
+    return [116 * y - 16, 500 * (x - y), 200 * (y - z), rgbColor[3]];
+}
+
+function labToRgb(labColor) {
+    var y = (labColor[0] + 16) / 116,
+        x = isNaN(labColor[1]) ? y : y + labColor[1] / 500,
+        z = isNaN(labColor[2]) ? y : y - labColor[2] / 200;
+    y = Yn * lab2xyz(y);
+    x = Xn * lab2xyz(x);
+    z = Zn * lab2xyz(z);
+    return [xyz2rgb(3.2404542 * x - 1.5371385 * y - 0.4985314 * z), // D65 -> sRGB
+    xyz2rgb(-0.9692660 * x + 1.8760108 * y + 0.0415560 * z), xyz2rgb(0.0556434 * x - 0.2040259 * y + 1.0572252 * z), labColor[3]];
+}
+
+// HCL
+function rgbToHcl(rgbColor) {
+    var labColor = rgbToLab(rgbColor);
+    var l = labColor[0],
+        a = labColor[1],
+        b = labColor[2];
+    var h = Math.atan2(b, a) * rad2deg;
+    return [h < 0 ? h + 360 : h, Math.sqrt(a * a + b * b), l, rgbColor[3]];
+}
+
+function hclToRgb(hclColor) {
+    var h = hclColor[0] * deg2rad,
+        c = hclColor[1],
+        l = hclColor[2];
+    return labToRgb([l, Math.cos(h) * c, Math.sin(h) * c, hclColor[3]]);
+}
+
+module.exports = {
+    lab: {
+        forward: rgbToLab,
+        reverse: labToRgb
+    },
+    hcl: {
+        forward: rgbToHcl,
+        reverse: hclToRgb
+    }
+};
+
+},{}],4:[function(require,module,exports){
+'use strict';
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
+var colorSpaces = require('./color_spaces');
+var parseColor = require('../util/parse_color');
+var extend = require('../util/extend');
+var getType = require('../util/get_type');
+
+function identityFunction(x) {
+    return x;
+}
+
+function createFunction(parameters, propertySpec) {
+    var isColor = propertySpec.type === 'color';
+
+    var fun = void 0;
+
+    if (!isFunctionDefinition(parameters)) {
+        if (isColor && parameters) {
+            parameters = parseColor(parameters);
+        }
+        fun = function fun() {
+            return parameters;
+        };
+        fun.isFeatureConstant = true;
+        fun.isZoomConstant = true;
+    } else {
+        var zoomAndFeatureDependent = parameters.stops && _typeof(parameters.stops[0][0]) === 'object';
+        var featureDependent = zoomAndFeatureDependent || parameters.property !== undefined;
+        var zoomDependent = zoomAndFeatureDependent || !featureDependent;
+        var type = parameters.type || (propertySpec.function === 'interpolated' ? 'exponential' : 'interval');
+
+        if (isColor) {
+            parameters = extend({}, parameters);
+
+            if (parameters.stops) {
+                parameters.stops = parameters.stops.map(function (stop) {
+                    return [stop[0], parseColor(stop[1])];
+                });
+            }
+
+            if (parameters.default) {
+                parameters.default = parseColor(parameters.default);
+            } else {
+                parameters.default = parseColor(propertySpec.default);
+            }
+        }
+
+        var innerFun = void 0;
+        var hashedStops = void 0;
+        var categoricalKeyType = void 0;
+        if (type === 'exponential') {
+            innerFun = evaluateExponentialFunction;
+        } else if (type === 'interval') {
+            innerFun = evaluateIntervalFunction;
+        } else if (type === 'categorical') {
+            innerFun = evaluateCategoricalFunction;
+
+            // For categorical functions, generate an Object as a hashmap of the stops for fast searching
+            hashedStops = Object.create(null);
+            var _iteratorNormalCompletion = true;
+            var _didIteratorError = false;
+            var _iteratorError = undefined;
+
+            try {
+                for (var _iterator = parameters.stops[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+                    var stop = _step.value;
+
+                    hashedStops[stop[0]] = stop[1];
+                }
+
+                // Infer key type based on first stop key-- used to encforce strict type checking later
+            } catch (err) {
+                _didIteratorError = true;
+                _iteratorError = err;
+            } finally {
+                try {
+                    if (!_iteratorNormalCompletion && _iterator.return) {
+                        _iterator.return();
+                    }
+                } finally {
+                    if (_didIteratorError) {
+                        throw _iteratorError;
+                    }
+                }
+            }
+
+            categoricalKeyType = _typeof(parameters.stops[0][0]);
+        } else if (type === 'identity') {
+            innerFun = evaluateIdentityFunction;
+        } else {
+            throw new Error('Unknown function type "' + type + '"');
+        }
+
+        var outputFunction = void 0;
+
+        // If we're interpolating colors in a color system other than RGBA,
+        // first translate all stop values to that color system, then interpolate
+        // arrays as usual. The `outputFunction` option lets us then translate
+        // the result of that interpolation back into RGBA.
+        if (parameters.colorSpace && parameters.colorSpace !== 'rgb') {
+            if (colorSpaces[parameters.colorSpace]) {
+                var colorspace = colorSpaces[parameters.colorSpace];
+                // Avoid mutating the parameters value
+                parameters = JSON.parse(JSON.stringify(parameters));
+                for (var s = 0; s < parameters.stops.length; s++) {
+                    parameters.stops[s] = [parameters.stops[s][0], colorspace.forward(parameters.stops[s][1])];
+                }
+                outputFunction = colorspace.reverse;
+            } else {
+                throw new Error('Unknown color space: ' + parameters.colorSpace);
+            }
+        } else {
+            outputFunction = identityFunction;
+        }
+
+        if (zoomAndFeatureDependent) {
+            var featureFunctions = {};
+            var zoomStops = [];
+            for (var _s = 0; _s < parameters.stops.length; _s++) {
+                var _stop = parameters.stops[_s];
+                var zoom = _stop[0].zoom;
+                if (featureFunctions[zoom] === undefined) {
+                    featureFunctions[zoom] = {
+                        zoom: zoom,
+                        type: parameters.type,
+                        property: parameters.property,
+                        stops: []
+                    };
+                    zoomStops.push(zoom);
+                }
+                featureFunctions[zoom].stops.push([_stop[0].value, _stop[1]]);
+            }
+
+            var featureFunctionStops = [];
+            var _iteratorNormalCompletion2 = true;
+            var _didIteratorError2 = false;
+            var _iteratorError2 = undefined;
+
+            try {
+                for (var _iterator2 = zoomStops[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+                    var z = _step2.value;
+
+                    featureFunctionStops.push([featureFunctions[z].zoom, createFunction(featureFunctions[z], propertySpec)]);
+                }
+            } catch (err) {
+                _didIteratorError2 = true;
+                _iteratorError2 = err;
+            } finally {
+                try {
+                    if (!_iteratorNormalCompletion2 && _iterator2.return) {
+                        _iterator2.return();
+                    }
+                } finally {
+                    if (_didIteratorError2) {
+                        throw _iteratorError2;
+                    }
+                }
+            }
+
+            fun = function fun(zoom, feature) {
+                return outputFunction(evaluateExponentialFunction({
+                    stops: featureFunctionStops,
+                    base: parameters.base
+                }, propertySpec, zoom)(zoom, feature));
+            };
+            fun.isFeatureConstant = false;
+            fun.isZoomConstant = false;
+        } else if (zoomDependent) {
+            fun = function fun(zoom) {
+                return outputFunction(innerFun(parameters, propertySpec, zoom, hashedStops, categoricalKeyType));
+            };
+            fun.isFeatureConstant = true;
+            fun.isZoomConstant = false;
+        } else {
+            fun = function fun(zoom, feature) {
+                var value = feature[parameters.property];
+                if (value === undefined) {
+                    return coalesce(parameters.default, propertySpec.default);
+                }
+                return outputFunction(innerFun(parameters, propertySpec, value, hashedStops, categoricalKeyType));
+            };
+            fun.isFeatureConstant = false;
+            fun.isZoomConstant = true;
+        }
+    }
+
+    return fun;
+}
+
+function coalesce(a, b, c) {
+    if (a !== undefined) return a;
+    if (b !== undefined) return b;
+    if (c !== undefined) return c;
+}
+
+function evaluateCategoricalFunction(parameters, propertySpec, input, hashedStops, keyType) {
+    var evaluated = (typeof input === 'undefined' ? 'undefined' : _typeof(input)) === keyType ? hashedStops[input] : undefined; // Enforce strict typing on input
+    return coalesce(evaluated, parameters.default, propertySpec.default);
+}
+
+function evaluateIntervalFunction(parameters, propertySpec, input) {
+    // Edge cases
+    if (getType(input) !== 'number') return coalesce(parameters.default, propertySpec.default);
+    var n = parameters.stops.length;
+    if (n === 1) return parameters.stops[0][1];
+    if (input <= parameters.stops[0][0]) return parameters.stops[0][1];
+    if (input >= parameters.stops[n - 1][0]) return parameters.stops[n - 1][1];
+
+    var index = findStopLessThanOrEqualTo(parameters.stops, input);
+
+    return parameters.stops[index][1];
+}
+
+function evaluateExponentialFunction(parameters, propertySpec, input) {
+    var base = parameters.base !== undefined ? parameters.base : 1;
+
+    // Edge cases
+    if (getType(input) !== 'number') return coalesce(parameters.default, propertySpec.default);
+    var n = parameters.stops.length;
+    if (n === 1) return parameters.stops[0][1];
+    if (input <= parameters.stops[0][0]) return parameters.stops[0][1];
+    if (input >= parameters.stops[n - 1][0]) return parameters.stops[n - 1][1];
+
+    var index = findStopLessThanOrEqualTo(parameters.stops, input);
+
+    return interpolate(input, base, parameters.stops[index][0], parameters.stops[index + 1][0], parameters.stops[index][1], parameters.stops[index + 1][1]);
+}
+
+function evaluateIdentityFunction(parameters, propertySpec, input) {
+    if (propertySpec.type === 'color') {
+        input = parseColor(input);
+    } else if (getType(input) !== propertySpec.type) {
+        input = undefined;
+    }
+    return coalesce(input, parameters.default, propertySpec.default);
+}
+
+/**
+ * Returns the index of the last stop <= input, or 0 if it doesn't exist.
+ *
+ * @private
+ */
+function findStopLessThanOrEqualTo(stops, input) {
+    var n = stops.length;
+    var lowerIndex = 0;
+    var upperIndex = n - 1;
+    var currentIndex = 0;
+    var currentValue = void 0,
+        upperValue = void 0;
+
+    while (lowerIndex <= upperIndex) {
+        currentIndex = Math.floor((lowerIndex + upperIndex) / 2);
+        currentValue = stops[currentIndex][0];
+        upperValue = stops[currentIndex + 1][0];
+        if (input === currentValue || input > currentValue && input < upperValue) {
+            // Search complete
+            return currentIndex;
+        } else if (currentValue < input) {
+            lowerIndex = currentIndex + 1;
+        } else if (currentValue > input) {
+            upperIndex = currentIndex - 1;
+        }
+    }
+
+    return Math.max(currentIndex - 1, 0);
+}
+
+function interpolate(input, base, inputLower, inputUpper, outputLower, outputUpper) {
+    if (typeof outputLower === 'function') {
+        return function () {
+            var evaluatedLower = outputLower.apply(undefined, arguments);
+            var evaluatedUpper = outputUpper.apply(undefined, arguments);
+            // Special case for fill-outline-color, which has no spec default.
+            if (evaluatedLower === undefined || evaluatedUpper === undefined) {
+                return undefined;
+            }
+            return interpolate(input, base, inputLower, inputUpper, evaluatedLower, evaluatedUpper);
+        };
+    } else if (outputLower.length) {
+        return interpolateArray(input, base, inputLower, inputUpper, outputLower, outputUpper);
+    } else {
+        return interpolateNumber(input, base, inputLower, inputUpper, outputLower, outputUpper);
+    }
+}
+
+function interpolateNumber(input, base, inputLower, inputUpper, outputLower, outputUpper) {
+    var ratio = interpolationFactor(input, base, inputLower, inputUpper);
+    return outputLower + ratio * (outputUpper - outputLower);
+}
+
+function interpolateArray(input, base, inputLower, inputUpper, outputLower, outputUpper) {
+    var output = [];
+    for (var i = 0; i < outputLower.length; i++) {
+        output[i] = interpolateNumber(input, base, inputLower, inputUpper, outputLower[i], outputUpper[i]);
+    }
+    return output;
+}
+
+function isFunctionDefinition(value) {
+    return (typeof value === 'undefined' ? 'undefined' : _typeof(value)) === 'object' && (value.stops || value.type === 'identity');
+}
+
+/**
+ * Returns a ratio that can be used to interpolate between exponential function
+ * stops.
+ *
+ * How it works:
+ * Two consecutive stop values define a (scaled and shifted) exponential
+ * function `f(x) = a * base^x + b`, where `base` is the user-specified base,
+ * and `a` and `b` are constants affording sufficient degrees of freedom to fit
+ * the function to the given stops.
+ *
+ * Here's a bit of algebra that lets us compute `f(x)` directly from the stop
+ * values without explicitly solving for `a` and `b`:
+ *
+ * First stop value: `f(x0) = y0 = a * base^x0 + b`
+ * Second stop value: `f(x1) = y1 = a * base^x1 + b`
+ * => `y1 - y0 = a(base^x1 - base^x0)`
+ * => `a = (y1 - y0)/(base^x1 - base^x0)`
+ *
+ * Desired value: `f(x) = y = a * base^x + b`
+ * => `f(x) = y0 + a * (base^x - base^x0)`
+ *
+ * From the above, we can replace the `a` in `a * (base^x - base^x0)` and do a
+ * little algebra:
+ * ```
+ * a * (base^x - base^x0) = (y1 - y0)/(base^x1 - base^x0) * (base^x - base^x0)
+ *                     = (y1 - y0) * (base^x - base^x0) / (base^x1 - base^x0)
+ * ```
+ *
+ * If we let `(base^x - base^x0) / (base^x1 base^x0)`, then we have
+ * `f(x) = y0 + (y1 - y0) * ratio`.  In other words, `ratio` may be treated as
+ * an interpolation factor between the two stops' output values.
+ *
+ * (Note: a slightly different form for `ratio`,
+ * `(base^(x-x0) - 1) / (base^(x1-x0) - 1) `, is equivalent, but requires fewer
+ * expensive `Math.pow()` operations.)
+ *
+ * @private
+*/
+function interpolationFactor(input, base, lowerValue, upperValue) {
+    var difference = upperValue - lowerValue;
+    var progress = input - lowerValue;
+
+    if (base === 1) {
+        return progress / difference;
+    } else {
+        return (Math.pow(base, progress) - 1) / (Math.pow(base, difference) - 1);
+    }
+}
+
+module.exports = createFunction;
+module.exports.isFunctionDefinition = isFunctionDefinition;
+module.exports.interpolationFactor = interpolationFactor;
+module.exports.findStopLessThanOrEqualTo = findStopLessThanOrEqualTo;
+
+},{"../util/extend":5,"../util/get_type":6,"../util/parse_color":7,"./color_spaces":3}],5:[function(require,module,exports){
+'use strict';
+
+module.exports = function (output) {
+    for (var i = 1; i < arguments.length; i++) {
+        var input = arguments[i];
+        for (var k in input) {
+            output[k] = input[k];
+        }
+    }
+    return output;
+};
+
+},{}],6:[function(require,module,exports){
+'use strict';
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
+module.exports = function getType(val) {
+    if (val instanceof Number) {
+        return 'number';
+    } else if (val instanceof String) {
+        return 'string';
+    } else if (val instanceof Boolean) {
+        return 'boolean';
+    } else if (Array.isArray(val)) {
+        return 'array';
+    } else if (val === null) {
+        return 'null';
+    } else {
+        return typeof val === 'undefined' ? 'undefined' : _typeof(val);
+    }
+};
+
+},{}],7:[function(require,module,exports){
+'use strict';
+
+var parseColorString = require('csscolorparser').parseCSSColor;
+
+module.exports = function parseColor(input) {
+    if (typeof input === 'string') {
+        var rgba = parseColorString(input);
+        if (!rgba) {
+            return undefined;
+        }
+
+        // GL expects all components to be in the range [0, 1] and to be
+        // multipled by the alpha value.
+        return [rgba[0] / 255 * rgba[3], rgba[1] / 255 * rgba[3], rgba[2] / 255 * rgba[3], rgba[3]];
+    } else if (Array.isArray(input)) {
+        return input;
+    } else {
+        return undefined;
+    }
+};
+
+},{"csscolorparser":8}],8:[function(require,module,exports){
+"use strict";
+
+// (c) Dean McNamee <dean@gmail.com>, 2012.
+//
+// https://github.com/deanm/css-color-parser-js
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+// http://www.w3.org/TR/css3-color/
+var kCSSColorTable = {
+  "transparent": [0, 0, 0, 0], "aliceblue": [240, 248, 255, 1],
+  "antiquewhite": [250, 235, 215, 1], "aqua": [0, 255, 255, 1],
+  "aquamarine": [127, 255, 212, 1], "azure": [240, 255, 255, 1],
+  "beige": [245, 245, 220, 1], "bisque": [255, 228, 196, 1],
+  "black": [0, 0, 0, 1], "blanchedalmond": [255, 235, 205, 1],
+  "blue": [0, 0, 255, 1], "blueviolet": [138, 43, 226, 1],
+  "brown": [165, 42, 42, 1], "burlywood": [222, 184, 135, 1],
+  "cadetblue": [95, 158, 160, 1], "chartreuse": [127, 255, 0, 1],
+  "chocolate": [210, 105, 30, 1], "coral": [255, 127, 80, 1],
+  "cornflowerblue": [100, 149, 237, 1], "cornsilk": [255, 248, 220, 1],
+  "crimson": [220, 20, 60, 1], "cyan": [0, 255, 255, 1],
+  "darkblue": [0, 0, 139, 1], "darkcyan": [0, 139, 139, 1],
+  "darkgoldenrod": [184, 134, 11, 1], "darkgray": [169, 169, 169, 1],
+  "darkgreen": [0, 100, 0, 1], "darkgrey": [169, 169, 169, 1],
+  "darkkhaki": [189, 183, 107, 1], "darkmagenta": [139, 0, 139, 1],
+  "darkolivegreen": [85, 107, 47, 1], "darkorange": [255, 140, 0, 1],
+  "darkorchid": [153, 50, 204, 1], "darkred": [139, 0, 0, 1],
+  "darksalmon": [233, 150, 122, 1], "darkseagreen": [143, 188, 143, 1],
+  "darkslateblue": [72, 61, 139, 1], "darkslategray": [47, 79, 79, 1],
+  "darkslategrey": [47, 79, 79, 1], "darkturquoise": [0, 206, 209, 1],
+  "darkviolet": [148, 0, 211, 1], "deeppink": [255, 20, 147, 1],
+  "deepskyblue": [0, 191, 255, 1], "dimgray": [105, 105, 105, 1],
+  "dimgrey": [105, 105, 105, 1], "dodgerblue": [30, 144, 255, 1],
+  "firebrick": [178, 34, 34, 1], "floralwhite": [255, 250, 240, 1],
+  "forestgreen": [34, 139, 34, 1], "fuchsia": [255, 0, 255, 1],
+  "gainsboro": [220, 220, 220, 1], "ghostwhite": [248, 248, 255, 1],
+  "gold": [255, 215, 0, 1], "goldenrod": [218, 165, 32, 1],
+  "gray": [128, 128, 128, 1], "green": [0, 128, 0, 1],
+  "greenyellow": [173, 255, 47, 1], "grey": [128, 128, 128, 1],
+  "honeydew": [240, 255, 240, 1], "hotpink": [255, 105, 180, 1],
+  "indianred": [205, 92, 92, 1], "indigo": [75, 0, 130, 1],
+  "ivory": [255, 255, 240, 1], "khaki": [240, 230, 140, 1],
+  "lavender": [230, 230, 250, 1], "lavenderblush": [255, 240, 245, 1],
+  "lawngreen": [124, 252, 0, 1], "lemonchiffon": [255, 250, 205, 1],
+  "lightblue": [173, 216, 230, 1], "lightcoral": [240, 128, 128, 1],
+  "lightcyan": [224, 255, 255, 1], "lightgoldenrodyellow": [250, 250, 210, 1],
+  "lightgray": [211, 211, 211, 1], "lightgreen": [144, 238, 144, 1],
+  "lightgrey": [211, 211, 211, 1], "lightpink": [255, 182, 193, 1],
+  "lightsalmon": [255, 160, 122, 1], "lightseagreen": [32, 178, 170, 1],
+  "lightskyblue": [135, 206, 250, 1], "lightslategray": [119, 136, 153, 1],
+  "lightslategrey": [119, 136, 153, 1], "lightsteelblue": [176, 196, 222, 1],
+  "lightyellow": [255, 255, 224, 1], "lime": [0, 255, 0, 1],
+  "limegreen": [50, 205, 50, 1], "linen": [250, 240, 230, 1],
+  "magenta": [255, 0, 255, 1], "maroon": [128, 0, 0, 1],
+  "mediumaquamarine": [102, 205, 170, 1], "mediumblue": [0, 0, 205, 1],
+  "mediumorchid": [186, 85, 211, 1], "mediumpurple": [147, 112, 219, 1],
+  "mediumseagreen": [60, 179, 113, 1], "mediumslateblue": [123, 104, 238, 1],
+  "mediumspringgreen": [0, 250, 154, 1], "mediumturquoise": [72, 209, 204, 1],
+  "mediumvioletred": [199, 21, 133, 1], "midnightblue": [25, 25, 112, 1],
+  "mintcream": [245, 255, 250, 1], "mistyrose": [255, 228, 225, 1],
+  "moccasin": [255, 228, 181, 1], "navajowhite": [255, 222, 173, 1],
+  "navy": [0, 0, 128, 1], "oldlace": [253, 245, 230, 1],
+  "olive": [128, 128, 0, 1], "olivedrab": [107, 142, 35, 1],
+  "orange": [255, 165, 0, 1], "orangered": [255, 69, 0, 1],
+  "orchid": [218, 112, 214, 1], "palegoldenrod": [238, 232, 170, 1],
+  "palegreen": [152, 251, 152, 1], "paleturquoise": [175, 238, 238, 1],
+  "palevioletred": [219, 112, 147, 1], "papayawhip": [255, 239, 213, 1],
+  "peachpuff": [255, 218, 185, 1], "peru": [205, 133, 63, 1],
+  "pink": [255, 192, 203, 1], "plum": [221, 160, 221, 1],
+  "powderblue": [176, 224, 230, 1], "purple": [128, 0, 128, 1],
+  "rebeccapurple": [102, 51, 153, 1],
+  "red": [255, 0, 0, 1], "rosybrown": [188, 143, 143, 1],
+  "royalblue": [65, 105, 225, 1], "saddlebrown": [139, 69, 19, 1],
+  "salmon": [250, 128, 114, 1], "sandybrown": [244, 164, 96, 1],
+  "seagreen": [46, 139, 87, 1], "seashell": [255, 245, 238, 1],
+  "sienna": [160, 82, 45, 1], "silver": [192, 192, 192, 1],
+  "skyblue": [135, 206, 235, 1], "slateblue": [106, 90, 205, 1],
+  "slategray": [112, 128, 144, 1], "slategrey": [112, 128, 144, 1],
+  "snow": [255, 250, 250, 1], "springgreen": [0, 255, 127, 1],
+  "steelblue": [70, 130, 180, 1], "tan": [210, 180, 140, 1],
+  "teal": [0, 128, 128, 1], "thistle": [216, 191, 216, 1],
+  "tomato": [255, 99, 71, 1], "turquoise": [64, 224, 208, 1],
+  "violet": [238, 130, 238, 1], "wheat": [245, 222, 179, 1],
+  "white": [255, 255, 255, 1], "whitesmoke": [245, 245, 245, 1],
+  "yellow": [255, 255, 0, 1], "yellowgreen": [154, 205, 50, 1] };
+
+function clamp_css_byte(i) {
+  // Clamp to integer 0 .. 255.
+  i = Math.round(i); // Seems to be what Chrome does (vs truncation).
+  return i < 0 ? 0 : i > 255 ? 255 : i;
+}
+
+function clamp_css_float(f) {
+  // Clamp to float 0.0 .. 1.0.
+  return f < 0 ? 0 : f > 1 ? 1 : f;
+}
+
+function parse_css_int(str) {
+  // int or percentage.
+  if (str[str.length - 1] === '%') return clamp_css_byte(parseFloat(str) / 100 * 255);
+  return clamp_css_byte(parseInt(str));
+}
+
+function parse_css_float(str) {
+  // float or percentage.
+  if (str[str.length - 1] === '%') return clamp_css_float(parseFloat(str) / 100);
+  return clamp_css_float(parseFloat(str));
+}
+
+function css_hue_to_rgb(m1, m2, h) {
+  if (h < 0) h += 1;else if (h > 1) h -= 1;
+
+  if (h * 6 < 1) return m1 + (m2 - m1) * h * 6;
+  if (h * 2 < 1) return m2;
+  if (h * 3 < 2) return m1 + (m2 - m1) * (2 / 3 - h) * 6;
+  return m1;
+}
+
+function parseCSSColor(css_str) {
+  // Remove all whitespace, not compliant, but should just be more accepting.
+  var str = css_str.replace(/ /g, '').toLowerCase();
+
+  // Color keywords (and transparent) lookup.
+  if (str in kCSSColorTable) return kCSSColorTable[str].slice(); // dup.
+
+  // #abc and #abc123 syntax.
+  if (str[0] === '#') {
+    if (str.length === 4) {
+      var iv = parseInt(str.substr(1), 16); // TODO(deanm): Stricter parsing.
+      if (!(iv >= 0 && iv <= 0xfff)) return null; // Covers NaN.
+      return [(iv & 0xf00) >> 4 | (iv & 0xf00) >> 8, iv & 0xf0 | (iv & 0xf0) >> 4, iv & 0xf | (iv & 0xf) << 4, 1];
+    } else if (str.length === 7) {
+      var iv = parseInt(str.substr(1), 16); // TODO(deanm): Stricter parsing.
+      if (!(iv >= 0 && iv <= 0xffffff)) return null; // Covers NaN.
+      return [(iv & 0xff0000) >> 16, (iv & 0xff00) >> 8, iv & 0xff, 1];
+    }
+
+    return null;
+  }
+
+  var op = str.indexOf('('),
+      ep = str.indexOf(')');
+  if (op !== -1 && ep + 1 === str.length) {
+    var fname = str.substr(0, op);
+    var params = str.substr(op + 1, ep - (op + 1)).split(',');
+    var alpha = 1; // To allow case fallthrough.
+    switch (fname) {
+      case 'rgba':
+        if (params.length !== 4) return null;
+        alpha = parse_css_float(params.pop());
+      // Fall through.
+      case 'rgb':
+        if (params.length !== 3) return null;
+        return [parse_css_int(params[0]), parse_css_int(params[1]), parse_css_int(params[2]), alpha];
+      case 'hsla':
+        if (params.length !== 4) return null;
+        alpha = parse_css_float(params.pop());
+      // Fall through.
+      case 'hsl':
+        if (params.length !== 3) return null;
+        var h = (parseFloat(params[0]) % 360 + 360) % 360 / 360; // 0 .. 1
+        // NOTE(deanm): According to the CSS spec s/l should only be
+        // percentages, but we don't bother and let float or percentage.
+        var s = parse_css_float(params[1]);
+        var l = parse_css_float(params[2]);
+        var m2 = l <= 0.5 ? l * (s + 1) : l + s - l * s;
+        var m1 = l * 2 - m2;
+        return [clamp_css_byte(css_hue_to_rgb(m1, m2, h + 1 / 3) * 255), clamp_css_byte(css_hue_to_rgb(m1, m2, h) * 255), clamp_css_byte(css_hue_to_rgb(m1, m2, h - 1 / 3) * 255), alpha];
+      default:
+        return null;
+    }
+  }
+
+  return null;
+}
+
+try {
+  exports.parseCSSColor = parseCSSColor;
+} catch (e) {}
+
+},{}],9:[function(require,module,exports){
+'use strict';
+
+var fontWeights = {
+  thin: 100,
+  hairline: 100,
+  'ultra-light': 100,
+  'extra-light': 100,
+  light: 200,
+  book: 300,
+  regular: 400,
+  normal: 400,
+  plain: 400,
+  roman: 400,
+  standard: 400,
+  medium: 500,
+  'semi-bold': 600,
+  'demi-bold': 600,
+  bold: 700,
+  heavy: 800,
+  black: 800,
+  'extra-bold': 800,
+  'ultra-black': 900,
+  'extra-black': 900,
+  'ultra-bold': 900,
+  'heavy-black': 900,
+  fat: 900,
+  poster: 900
+};
+var sp = ' ';
+
+var fontCache = {};
+
+module.exports = function (font, size) {
+  var cssData = fontCache[font];
+  if (!cssData) {
+    var parts = font.split(' ');
+    var maybeWeight = parts[parts.length - 1].toLowerCase();
+    var weight = 'normal';
+    var style = 'normal';
+    if (maybeWeight == 'normal' || maybeWeight == 'italic' || maybeWeight == 'oblique') {
+      style = maybeWeight;
+      parts.pop();
+      maybeWeight = parts[parts.length - 1].toLowerCase();
+    }
+    for (var w in fontWeights) {
+      if (maybeWeight == w || maybeWeight == w.replace('-', '') || maybeWeight == w.replace('-', ' ')) {
+        weight = fontWeights[w];
+        parts.pop();
+        break;
+      }
+    }
+    if (typeof maybeWeight == 'number') {
+      weight = maybeWeight;
+    }
+    var fontFamily = parts.join(' ');
+    // CSS font property: font-style font-weight font-size font-family
+    cssData = fontCache[font] = [style, weight, fontFamily];
+  }
+  return cssData[0] + sp + cssData[1] + sp + size + 'px' + sp + cssData[2];
+};
+
+},{}],10:[function(require,module,exports){
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; /*
+                                                                                                                                                                                                                                                                              mapbox-to-ol-style - Create OpenLayers style functions from Mapbox Style objects
+                                                                                                                                                                                                                                                                              Copyright 2016-present Boundless Spatial, Inc.
+                                                                                                                                                                                                                                                                              License: https://raw.githubusercontent.com/boundlessgeo/mapbox-to-ol-style/master/LICENSE.md
+                                                                                                                                                                                                                                                                              */
+
+exports.default = function (glStyle, source, resolutions, spriteData, spriteImageUrl, fonts) {
+  if (!resolutions) {
+    resolutions = [];
+    for (var res = 156543.03392804097; resolutions.length < 22; res /= 2) {
+      resolutions.push(res);
+    }
+  }
+  if ((typeof glStyle === 'undefined' ? 'undefined' : _typeof(glStyle)) == 'object') {
+    // We do not want to modify the original, so we deep-clone it
+    glStyle = JSON.stringify(glStyle);
+  }
+  glStyle = JSON.parse(glStyle);
+  if (glStyle.version != 8) {
+    throw new Error('glStyle version 8 required.');
+  }
+
+  var ctx = document.createElement('CANVAS').getContext('2d');
+  var measureCache = {};
+  function wrapText(text, font, em) {
+    var key = em + font + text;
+    var wrappedText = measureCache[key];
+    if (!wrappedText) {
+      ctx.font = font;
+      var oneEm = ctx.measureText('M').width;
+      var width = oneEm * em;
+      var words = text.split(' ');
+      var line = '';
+      var lines = [];
+      for (var i = 0, ii = words.length; i < ii; ++i) {
+        var word = words[i];
+        if (ctx.measureText(line + word).width <= width) {
+          line += (line ? ' ' : '') + word;
+        } else {
+          lines.push(line);
+          line = word;
+        }
+      }
+      if (line) {
+        lines.push(line);
+      }
+      wrappedText = measureCache[key] = lines.join('\n');
+    }
+    return wrappedText;
+  }
+
+  var allLayers = glStyle.layers;
+  var layersBySourceLayer = {};
+  for (var i = 0, ii = allLayers.length; i < ii; ++i) {
+    var layer = allLayers[i];
+    if (!layer.layout) {
+      layer.layout = {};
+    }
+    resolveRef(layer, glStyle);
+    if (typeof source == 'string' && layer.source == source || source.indexOf(layer.id) !== -1) {
+      var sourceLayer = layer['source-layer'];
+      var layers = layersBySourceLayer[sourceLayer];
+      if (!layers) {
+        layers = layersBySourceLayer[sourceLayer] = [];
+      }
+      layers.push({
+        layer: layer,
+        index: i
+      });
+      preprocess(layer, fonts);
+    }
+  }
+
+  var textHalo = new _stroke2.default();
+  var textColor = new _fill2.default();
+
+  var iconImageCache = {};
+
+  var styles = [];
+
+  return function (feature, resolution) {
+    var properties = feature.getProperties();
+    var layers = layersBySourceLayer[properties.layer];
+    if (!layers) {
+      return;
+    }
+    var zoom = resolutions.indexOf(resolution);
+    if (zoom == -1) {
+      zoom = getZoomForResolution(resolution, resolutions);
+    }
+    var type = types[feature.getGeometry().getType()];
+    var f = {
+      properties: properties,
+      type: type
+    };
+    var stylesLength = -1;
+    for (var i = 0, ii = layers.length; i < ii; ++i) {
+      var layerData = layers[i];
+      var layer = layerData.layer;
+      var paint = layer.paint;
+      if (paint.visibility === 'none' || 'minzoom' in layer && zoom < layer.minzoom || 'maxzoom' in layer && zoom >= layer.maxzoom) {
+        continue;
+      }
+      if (!layer.filter || layer.filter(f)) {
+        var color, opacity, fill, stroke, strokeColor, style, text;
+        var index = layerData.index;
+        if (type == 3) {
+          if (!('fill-pattern' in paint) && 'fill-color' in paint) {
+            opacity = paint['fill-opacity'](zoom, properties);
+            color = colorWithOpacity(paint['fill-color'](zoom, properties), opacity);
+            if (color) {
+              ++stylesLength;
+              style = styles[stylesLength];
+              if (!style || !style.getFill() || style.getStroke() || style.getText()) {
+                style = styles[stylesLength] = new _style2.default({
+                  fill: new _fill2.default()
+                });
+              }
+              fill = style.getFill();
+              fill.setColor(color);
+              style.setZIndex(index);
+            }
+            if ('fill-outline-color' in paint) {
+              strokeColor = colorWithOpacity(paint['fill-outline-color'](zoom, properties), opacity);
+            }
+            if (strokeColor) {
+              ++stylesLength;
+              style = styles[stylesLength];
+              if (!style || !style.getStroke() || style.getFill() || style.getText()) {
+                style = styles[stylesLength] = new _style2.default({
+                  stroke: new _stroke2.default()
+                });
+              }
+              stroke = style.getStroke();
+              stroke.setLineCap(defaults['line-cap']);
+              stroke.setLineJoin(defaults['line-join']);
+              stroke.setMiterLimit(defaults['line-miter-limit']);
+              stroke.setColor(strokeColor);
+              stroke.setWidth(1);
+              stroke.setLineDash(null);
+              style.setZIndex(index);
+            }
+          }
+        }
+        if (type != 1) {
+          color = !('line-pattern' in paint) && 'line-color' in paint ? colorWithOpacity(paint['line-color'](zoom, properties), paint['line-opacity'](zoom, properties)) : undefined;
+          var width = paint['line-width'](zoom, properties);
+          if (color && width > 0) {
+            ++stylesLength;
+            style = styles[stylesLength];
+            if (!style || !style.getStroke() || style.getFill() || style.getText()) {
+              style = styles[stylesLength] = new _style2.default({
+                stroke: new _stroke2.default()
+              });
+            }
+            stroke = style.getStroke();
+            stroke.setLineCap(paint['line-cap'](zoom, properties));
+            stroke.setLineJoin(paint['line-join'](zoom, properties));
+            stroke.setMiterLimit(paint['line-miter-limit'](zoom, properties));
+            stroke.setColor(color);
+            stroke.setWidth(width);
+            stroke.setLineDash(paint['line-dasharray'] ? paint['line-dasharray'](zoom, properties).map(function (x) {
+              return x * width;
+            }) : null);
+            style.setZIndex(index);
+          }
+        }
+
+        var icon;
+        if (type == 1 && 'icon-image' in paint) {
+          var iconImage = paint['icon-image'](zoom, properties);
+          icon = fromTemplate(iconImage, properties);
+          style = iconImageCache[icon];
+          if (!style && spriteData && spriteImageUrl) {
+            var spriteImageData = spriteData[icon];
+            if (spriteImageData) {
+              style = iconImageCache[icon] = new _style2.default({
+                image: new _icon2.default({
+                  src: spriteImageUrl,
+                  size: [spriteImageData.width, spriteImageData.height],
+                  offset: [spriteImageData.x, spriteImageData.y],
+                  scale: paint['icon-size'](zoom, properties) / spriteImageData.pixelRatio
+                })
+              });
+            }
+          }
+          if (style) {
+            ++stylesLength;
+            var iconImg = style.getImage();
+            iconImg.setRotation(deg2rad(paint['icon-rotate'](zoom, properties)));
+            iconImg.setOpacity(paint['icon-opacity'](zoom, properties));
+            style.setZIndex(index);
+            styles[stylesLength] = style;
+          }
+        }
+
+        if (type == 1 && 'circle-radius' in paint) {
+          ++stylesLength;
+          var cache_key = paint['circle-radius'](zoom, properties) + '.' + paint['circle-stroke-color'](zoom, properties) + '.' + paint['circle-color'](zoom, properties);
+          style = iconImageCache[cache_key];
+          if (!style) {
+            style = new _style2.default({
+              image: new _circle2.default({
+                radius: paint['circle-radius'](zoom, properties),
+                stroke: new _stroke2.default({
+                  color: colorWithOpacity(paint['circle-stroke-color'](zoom, properties), opacity)
+                }),
+                fill: new _fill2.default({
+                  color: colorWithOpacity(paint['circle-color'](zoom, properties), opacity)
+                })
+              })
+            });
+          }
+          style.setZIndex(index);
+          styles[stylesLength] = style;
+        }
+
+        var label;
+        if ('text-field' in paint) {
+          var textField = paint['text-field'](zoom, properties);
+          label = fromTemplate(textField, properties);
+        }
+        // TODO Add LineString handling as soon as it's supporte in OpenLayers
+        if (label && type !== 2) {
+          ++stylesLength;
+          style = styles[stylesLength];
+          if (!style || !style.getText() || style.getFill() || style.getStroke()) {
+            style = styles[stylesLength] = new _style2.default({
+              text: new _text2.default({
+                text: '',
+                fill: textColor
+              })
+            });
+          }
+          text = style.getText();
+          var textSize = paint['text-size'](zoom, properties);
+          var font = (0, _mapboxToCssFont2.default)(fontMap[paint['text-font'](zoom, properties)], textSize);
+          var textTransform = paint['text-transform'];
+          if (textTransform == 'uppercase') {
+            label = label.toUpperCase();
+          } else if (textTransform == 'lowercase') {
+            label = label.toLowerCase();
+          }
+          var wrappedLabel = wrapText(label, font, paint['text-max-width'](zoom, properties));
+          text.setText(wrappedLabel);
+          text.setFont(font);
+          var offset = paint['text-offset'](zoom, properties);
+          var yOffset = offset[1] * textSize + (wrappedLabel.split('\n').length - 1) * textSize;
+          var anchor = paint['text-anchor'](zoom, properties);
+          if (anchor.indexOf('top') == 0) {
+            yOffset += 0.5 * textSize;
+          } else if (anchor.indexOf('bottom') == 0) {
+            yOffset -= 0.5 * textSize;
+          }
+          text.setOffsetX(offset[0] * textSize);
+          text.setOffsetY(yOffset);
+          text.getFill().setColor(paint['text-color'](zoom, properties));
+          if (paint['text-halo-width']) {
+            textHalo.setWidth(paint['text-halo-width'](zoom, properties));
+            textHalo.setColor(paint['text-halo-color'](zoom, properties));
+            text.setStroke(textHalo);
+          } else {
+            text.setStroke(undefined);
+          }
+          style.setZIndex(index);
+        }
+      }
+    }
+
+    if (stylesLength > -1) {
+      styles.length = stylesLength + 1;
+      return styles;
+    }
+  };
+};
+
+var _style = require('ol/style/style');
+
+var _style2 = _interopRequireDefault(_style);
+
+var _fill = require('ol/style/fill');
+
+var _fill2 = _interopRequireDefault(_fill);
+
+var _stroke = require('ol/style/stroke');
+
+var _stroke2 = _interopRequireDefault(_stroke);
+
+var _icon = require('ol/style/icon');
+
+var _icon2 = _interopRequireDefault(_icon);
+
+var _circle = require('ol/style/circle');
+
+var _circle2 = _interopRequireDefault(_circle);
+
+var _text = require('ol/style/text');
+
+var _text2 = _interopRequireDefault(_text);
+
+var _function = require('@mapbox/mapbox-gl-style-spec/function');
+
+var _function2 = _interopRequireDefault(_function);
+
+var _feature_filter = require('@mapbox/mapbox-gl-style-spec/feature_filter');
+
+var _feature_filter2 = _interopRequireDefault(_feature_filter);
+
+var _mapboxToCssFont = require('mapbox-to-css-font');
+
+var _mapboxToCssFont2 = _interopRequireDefault(_mapboxToCssFont);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var functions = {
+  interpolated: ['line-miter-limit', 'fill-opacity', 'line-opacity', 'line-width', 'text-halo-width', 'text-max-width', 'text-offset', 'text-size', 'icon-opacity', 'icon-rotate', 'icon-size', 'circle-radius'],
+  'piecewise-constant': ['fill-color', 'fill-outline-color', 'icon-image', 'line-cap', 'line-color', 'line-join', 'line-dasharray', 'text-anchor', 'text-color', 'text-field', 'text-font', 'text-halo-color', 'circle-color', 'circle-stroke-color']
+};
+
+var defaults = {
+  'fill-opacity': 1,
+  'line-cap': 'butt',
+  'line-join': 'miter',
+  'line-miter-limit': 2,
+  'line-opacity': 1,
+  'line-width': 1,
+  'text-anchor': 'center',
+  'text-color': '#000000',
+  'text-font': ['Open Sans Regular', 'Arial Unicode MS Regular'],
+  'text-halo-color': 'rgba(0, 0, 0, 0)',
+  'text-halo-width': 0,
+  'text-max-width': 10,
+  'text-offset': [0, 0],
+  'text-size': 16,
+  'icon-opacity': 1,
+  'icon-rotate': 0,
+  'icon-size': 1,
+  'circle-color': '#000000',
+  'circle-stroke-color': '#000000'
+};
+
+var types = {
+  'Point': 1,
+  'MultiPoint': 1,
+  'LineString': 2,
+  'MultiLineString': 2,
+  'Polygon': 3,
+  'MultiPolygon': 3
+};
+
+function applyDefaults(properties) {
+  for (var property in defaults) {
+    if (!(property in properties)) {
+      properties[property] = defaults[property];
+    }
+  }
+}
+
+function applyLayoutToPaint(layer) {
+  for (var property in layer.layout) {
+    if (!layer.paint[property]) {
+      layer.paint[property] = layer.layout[property];
+    }
+  }
+}
+
+function convertToFunctions(properties, type) {
+  var propertySpec = {
+    function: type
+  };
+  for (var i = 0, ii = functions[type].length; i < ii; ++i) {
+    var property = functions[type][i];
+    if (property in properties) {
+      properties[property] = (0, _function2.default)(properties[property], propertySpec);
+    }
+  }
+}
+
+var fontMap = {};
+
+function chooseFont(fonts, availableFonts) {
+  if (availableFonts) {
+    var font, i, ii;
+    if (!Array.isArray(fonts)) {
+      var stops = fonts.stops;
+      if (stops) {
+        for (i = 0, ii = stops.length; i < ii; ++i) {
+          chooseFont(stops[i][1], availableFonts);
+        }
+      }
+      return;
+    }
+    if (!fontMap[fonts]) {
+      for (i = 0, ii = fonts.length; i < ii; ++i) {
+        font = fonts[i];
+        if (availableFonts.indexOf(font) >= -1) {
+          fontMap[fonts] = font;
+          break;
+        }
+      }
+    }
+  } else {
+    fontMap[fonts] = fonts[0];
+  }
+}
+
+function preprocess(layer, fonts) {
+  if (!layer.paint) {
+    layer.paint = {};
+  }
+  if (!layer.ref) {
+    applyLayoutToPaint(layer);
+  }
+  applyDefaults(layer.paint);
+  if (layer.paint['text-field']) {
+    chooseFont(layer.paint['text-font'], fonts);
+  }
+  if (Array.isArray(layer.filter)) {
+    layer.filter = (0, _feature_filter2.default)(layer.filter);
+  }
+  convertToFunctions(layer.paint, 'interpolated');
+  convertToFunctions(layer.paint, 'piecewise-constant');
+}
+
+function resolveRef(layer, glStyleObj) {
+  if (layer.ref) {
+    var layers = glStyleObj.layers;
+    for (var i = 0, ii = layers.length; i < ii; ++i) {
+      var refLayer = layers[i];
+      if (refLayer.id == layer.ref) {
+        layer.type = refLayer.type;
+        layer.source = refLayer.source;
+        layer['source-layer'] = refLayer['source-layer'];
+        layer.minzoom = refLayer.minzoom;
+        layer.maxzoom = refLayer.maxzoom;
+        layer.filter = refLayer.filter;
+        layer.layout = refLayer.layout;
+        return;
+      }
+    }
+  }
+}
+
+function getZoomForResolution(resolution, resolutions) {
+  var candidate;
+  var i = 0,
+      ii = resolutions.length;
+  for (; i < ii; ++i) {
+    candidate = resolutions[i];
+    if (candidate < resolution && i + 1 < ii) {
+      var zoomFactor = resolutions[i] / resolutions[i + 1];
+      return i + Math.log(resolutions[i] / resolution) / Math.log(zoomFactor);
+    }
+  }
+  return ii - 1;
+}
+
+var colorElement = document.createElement('div');
+var colorRegEx = /^rgba?\((.*)\)$/;
+var colorCache = {};
+
+function colorWithOpacity(color, opacity) {
+  if (color && opacity !== undefined) {
+    var colorData = colorCache[color];
+    if (!colorData) {
+      colorElement.style.color = color;
+      document.body.appendChild(colorElement);
+      var colorString = getComputedStyle(colorElement).getPropertyValue('color');
+      document.body.removeChild(colorElement);
+      var colorArray = colorString.match(colorRegEx)[1].split(',').map(Number);
+      if (colorArray.length == 3) {
+        colorArray.push(1);
+      }
+      colorCache[color] = colorData = {
+        color: colorArray,
+        opacity: colorArray[3]
+      };
+    }
+    color = colorData.color;
+    color[3] = colorData.opacity * opacity;
+    if (color[3] === 0) {
+      color = undefined;
+    }
+  }
+  return color;
+}
+
+function deg2rad(degrees) {
+  return degrees * Math.PI / 180;
+}
+
+var templateRegEx = /^(.*)\{(.*)\}(.*)$/;
+
+function fromTemplate(text, properties) {
+  var parts = text.match(templateRegEx);
+  if (parts) {
+    var value = properties[parts[2]] || '';
+    return parts[1] + value + parts[3];
+  } else {
+    return text;
+  }
+}
+
+/**
+ * Creates a style function from the `glStyle` object for all layers that use
+ * the specified `source`, which needs to be a `"type": "vector"` or
+ * `"type": "geojson"` source.
+ *
+ * @param {string|Object} glStyle Mapbox Style object.
+ * @param {string|Array<string>} source `source` key or an array of layer `id`s
+ * from the Mapbox Style object. When a `source` key is provided, all layers for
+ * the specified source will be included in the style function. When layer `id`s
+ * are provided, they must be from layers that use the same source.
+ * @param {Array<number>} [resolutions=[156543.03392804097,
+ * 78271.51696402048, 39135.75848201024, 19567.87924100512, 9783.93962050256,
+ * 4891.96981025128, 2445.98490512564, 1222.99245256282, 611.49622628141,
+ * 305.748113140705, 152.8740565703525, 76.43702828517625, 38.21851414258813,
+ * 19.109257071294063, 9.554628535647032, 4.777314267823516, 2.388657133911758,
+ * 1.194328566955879, 0.5971642834779395, 0.29858214173896974,
+ * 0.14929107086948487, 0.07464553543474244]]
+ * Resolutions for mapping resolution to zoom level. For tile layers, this can
+ * be `layer.getSource().getTileGrid().getResolutions()`.
+ * @param {Object} [spriteData=undefined] Sprite data from the url specified in
+ * the Mapbox Style object's `sprite` property. Only required if a `sprite`
+ * property is specified in the Mapbox Style object.
+ * @param {Object} [spriteImageUrl=undefined] Sprite image url for the sprite
+ * specified in the Mapbox Style object's `sprite` property. Only required if a
+ * `sprite` property is specified in the Mapbox Style object.
+ * @param {Array<string>} [fonts=undefined] Array of available fonts, using the
+ * same font names as the Mapbox Style object. If not provided, the style
+ * function will always use the first font from the font array.
+ * @return {ol.style.StyleFunction} Style function for use in
+ * `ol.layer.Vector` or `ol.layer.VectorTile`.
+ */
+
+},{"@mapbox/mapbox-gl-style-spec/feature_filter":2,"@mapbox/mapbox-gl-style-spec/function":4,"mapbox-to-css-font":9,"ol/style/circle":"ol/style/circle","ol/style/fill":"ol/style/fill","ol/style/icon":"ol/style/icon","ol/style/stroke":"ol/style/stroke","ol/style/style":"ol/style/style","ol/style/text":"ol/style/text"}],11:[function(require,module,exports){
+"use strict";
+
+/* Web Font Loader v1.6.28 - (c) Adobe Systems, Google. License: Apache 2.0 */(function () {
+  function aa(a, b, c) {
+    return a.call.apply(a.bind, arguments);
+  }function ba(a, b, c) {
+    if (!a) throw Error();if (2 < arguments.length) {
+      var d = Array.prototype.slice.call(arguments, 2);return function () {
+        var c = Array.prototype.slice.call(arguments);Array.prototype.unshift.apply(c, d);return a.apply(b, c);
+      };
+    }return function () {
+      return a.apply(b, arguments);
+    };
+  }function p(a, b, c) {
+    p = Function.prototype.bind && -1 != Function.prototype.bind.toString().indexOf("native code") ? aa : ba;return p.apply(null, arguments);
+  }var q = Date.now || function () {
+    return +new Date();
+  };function ca(a, b) {
+    this.a = a;this.o = b || a;this.c = this.o.document;
+  }var da = !!window.FontFace;function t(a, b, c, d) {
+    b = a.c.createElement(b);if (c) for (var e in c) {
+      c.hasOwnProperty(e) && ("style" == e ? b.style.cssText = c[e] : b.setAttribute(e, c[e]));
+    }d && b.appendChild(a.c.createTextNode(d));return b;
+  }function u(a, b, c) {
+    a = a.c.getElementsByTagName(b)[0];a || (a = document.documentElement);a.insertBefore(c, a.lastChild);
+  }function v(a) {
+    a.parentNode && a.parentNode.removeChild(a);
+  }
+  function w(a, b, c) {
+    b = b || [];c = c || [];for (var d = a.className.split(/\s+/), e = 0; e < b.length; e += 1) {
+      for (var f = !1, g = 0; g < d.length; g += 1) {
+        if (b[e] === d[g]) {
+          f = !0;break;
+        }
+      }f || d.push(b[e]);
+    }b = [];for (e = 0; e < d.length; e += 1) {
+      f = !1;for (g = 0; g < c.length; g += 1) {
+        if (d[e] === c[g]) {
+          f = !0;break;
+        }
+      }f || b.push(d[e]);
+    }a.className = b.join(" ").replace(/\s+/g, " ").replace(/^\s+|\s+$/, "");
+  }function y(a, b) {
+    for (var c = a.className.split(/\s+/), d = 0, e = c.length; d < e; d++) {
+      if (c[d] == b) return !0;
+    }return !1;
+  }
+  function ea(a) {
+    return a.o.location.hostname || a.a.location.hostname;
+  }function z(a, b, c) {
+    function d() {
+      m && e && f && (m(g), m = null);
+    }b = t(a, "link", { rel: "stylesheet", href: b, media: "all" });var e = !1,
+        f = !0,
+        g = null,
+        m = c || null;da ? (b.onload = function () {
+      e = !0;d();
+    }, b.onerror = function () {
+      e = !0;g = Error("Stylesheet failed to load");d();
+    }) : setTimeout(function () {
+      e = !0;d();
+    }, 0);u(a, "head", b);
+  }
+  function A(a, b, c, d) {
+    var e = a.c.getElementsByTagName("head")[0];if (e) {
+      var f = t(a, "script", { src: b }),
+          g = !1;f.onload = f.onreadystatechange = function () {
+        g || this.readyState && "loaded" != this.readyState && "complete" != this.readyState || (g = !0, c && c(null), f.onload = f.onreadystatechange = null, "HEAD" == f.parentNode.tagName && e.removeChild(f));
+      };e.appendChild(f);setTimeout(function () {
+        g || (g = !0, c && c(Error("Script load timeout")));
+      }, d || 5E3);return f;
+    }return null;
+  };function B() {
+    this.a = 0;this.c = null;
+  }function C(a) {
+    a.a++;return function () {
+      a.a--;D(a);
+    };
+  }function E(a, b) {
+    a.c = b;D(a);
+  }function D(a) {
+    0 == a.a && a.c && (a.c(), a.c = null);
+  };function F(a) {
+    this.a = a || "-";
+  }F.prototype.c = function (a) {
+    for (var b = [], c = 0; c < arguments.length; c++) {
+      b.push(arguments[c].replace(/[\W_]+/g, "").toLowerCase());
+    }return b.join(this.a);
+  };function G(a, b) {
+    this.c = a;this.f = 4;this.a = "n";var c = (b || "n4").match(/^([nio])([1-9])$/i);c && (this.a = c[1], this.f = parseInt(c[2], 10));
+  }function fa(a) {
+    return H(a) + " " + (a.f + "00") + " 300px " + I(a.c);
+  }function I(a) {
+    var b = [];a = a.split(/,\s*/);for (var c = 0; c < a.length; c++) {
+      var d = a[c].replace(/['"]/g, "");-1 != d.indexOf(" ") || /^\d/.test(d) ? b.push("'" + d + "'") : b.push(d);
+    }return b.join(",");
+  }function J(a) {
+    return a.a + a.f;
+  }function H(a) {
+    var b = "normal";"o" === a.a ? b = "oblique" : "i" === a.a && (b = "italic");return b;
+  }
+  function ga(a) {
+    var b = 4,
+        c = "n",
+        d = null;a && ((d = a.match(/(normal|oblique|italic)/i)) && d[1] && (c = d[1].substr(0, 1).toLowerCase()), (d = a.match(/([1-9]00|normal|bold)/i)) && d[1] && (/bold/i.test(d[1]) ? b = 7 : /[1-9]00/.test(d[1]) && (b = parseInt(d[1].substr(0, 1), 10))));return c + b;
+  };function ha(a, b) {
+    this.c = a;this.f = a.o.document.documentElement;this.h = b;this.a = new F("-");this.j = !1 !== b.events;this.g = !1 !== b.classes;
+  }function ia(a) {
+    a.g && w(a.f, [a.a.c("wf", "loading")]);K(a, "loading");
+  }function L(a) {
+    if (a.g) {
+      var b = y(a.f, a.a.c("wf", "active")),
+          c = [],
+          d = [a.a.c("wf", "loading")];b || c.push(a.a.c("wf", "inactive"));w(a.f, c, d);
+    }K(a, "inactive");
+  }function K(a, b, c) {
+    if (a.j && a.h[b]) if (c) a.h[b](c.c, J(c));else a.h[b]();
+  };function ja() {
+    this.c = {};
+  }function ka(a, b, c) {
+    var d = [],
+        e;for (e in b) {
+      if (b.hasOwnProperty(e)) {
+        var f = a.c[e];f && d.push(f(b[e], c));
+      }
+    }return d;
+  };function M(a, b) {
+    this.c = a;this.f = b;this.a = t(this.c, "span", { "aria-hidden": "true" }, this.f);
+  }function N(a) {
+    u(a.c, "body", a.a);
+  }function O(a) {
+    return "display:block;position:absolute;top:-9999px;left:-9999px;font-size:300px;width:auto;height:auto;line-height:normal;margin:0;padding:0;font-variant:normal;white-space:nowrap;font-family:" + I(a.c) + ";" + ("font-style:" + H(a) + ";font-weight:" + (a.f + "00") + ";");
+  };function P(a, b, c, d, e, f) {
+    this.g = a;this.j = b;this.a = d;this.c = c;this.f = e || 3E3;this.h = f || void 0;
+  }P.prototype.start = function () {
+    var a = this.c.o.document,
+        b = this,
+        c = q(),
+        d = new Promise(function (d, e) {
+      function f() {
+        q() - c >= b.f ? e() : a.fonts.load(fa(b.a), b.h).then(function (a) {
+          1 <= a.length ? d() : setTimeout(f, 25);
+        }, function () {
+          e();
+        });
+      }f();
+    }),
+        e = null,
+        f = new Promise(function (a, d) {
+      e = setTimeout(d, b.f);
+    });Promise.race([f, d]).then(function () {
+      e && (clearTimeout(e), e = null);b.g(b.a);
+    }, function () {
+      b.j(b.a);
+    });
+  };function Q(a, b, c, d, e, f, g) {
+    this.v = a;this.B = b;this.c = c;this.a = d;this.s = g || "BESbswy";this.f = {};this.w = e || 3E3;this.u = f || null;this.m = this.j = this.h = this.g = null;this.g = new M(this.c, this.s);this.h = new M(this.c, this.s);this.j = new M(this.c, this.s);this.m = new M(this.c, this.s);a = new G(this.a.c + ",serif", J(this.a));a = O(a);this.g.a.style.cssText = a;a = new G(this.a.c + ",sans-serif", J(this.a));a = O(a);this.h.a.style.cssText = a;a = new G("serif", J(this.a));a = O(a);this.j.a.style.cssText = a;a = new G("sans-serif", J(this.a));a = O(a);this.m.a.style.cssText = a;N(this.g);N(this.h);N(this.j);N(this.m);
+  }var R = { D: "serif", C: "sans-serif" },
+      S = null;function T() {
+    if (null === S) {
+      var a = /AppleWebKit\/([0-9]+)(?:\.([0-9]+))/.exec(window.navigator.userAgent);S = !!a && (536 > parseInt(a[1], 10) || 536 === parseInt(a[1], 10) && 11 >= parseInt(a[2], 10));
+    }return S;
+  }Q.prototype.start = function () {
+    this.f.serif = this.j.a.offsetWidth;this.f["sans-serif"] = this.m.a.offsetWidth;this.A = q();U(this);
+  };
+  function la(a, b, c) {
+    for (var d in R) {
+      if (R.hasOwnProperty(d) && b === a.f[R[d]] && c === a.f[R[d]]) return !0;
+    }return !1;
+  }function U(a) {
+    var b = a.g.a.offsetWidth,
+        c = a.h.a.offsetWidth,
+        d;(d = b === a.f.serif && c === a.f["sans-serif"]) || (d = T() && la(a, b, c));d ? q() - a.A >= a.w ? T() && la(a, b, c) && (null === a.u || a.u.hasOwnProperty(a.a.c)) ? V(a, a.v) : V(a, a.B) : ma(a) : V(a, a.v);
+  }function ma(a) {
+    setTimeout(p(function () {
+      U(this);
+    }, a), 50);
+  }function V(a, b) {
+    setTimeout(p(function () {
+      v(this.g.a);v(this.h.a);v(this.j.a);v(this.m.a);b(this.a);
+    }, a), 0);
+  };function W(a, b, c) {
+    this.c = a;this.a = b;this.f = 0;this.m = this.j = !1;this.s = c;
+  }var X = null;W.prototype.g = function (a) {
+    var b = this.a;b.g && w(b.f, [b.a.c("wf", a.c, J(a).toString(), "active")], [b.a.c("wf", a.c, J(a).toString(), "loading"), b.a.c("wf", a.c, J(a).toString(), "inactive")]);K(b, "fontactive", a);this.m = !0;na(this);
+  };
+  W.prototype.h = function (a) {
+    var b = this.a;if (b.g) {
+      var c = y(b.f, b.a.c("wf", a.c, J(a).toString(), "active")),
+          d = [],
+          e = [b.a.c("wf", a.c, J(a).toString(), "loading")];c || d.push(b.a.c("wf", a.c, J(a).toString(), "inactive"));w(b.f, d, e);
+    }K(b, "fontinactive", a);na(this);
+  };function na(a) {
+    0 == --a.f && a.j && (a.m ? (a = a.a, a.g && w(a.f, [a.a.c("wf", "active")], [a.a.c("wf", "loading"), a.a.c("wf", "inactive")]), K(a, "active")) : L(a.a));
+  };function oa(a) {
+    this.j = a;this.a = new ja();this.h = 0;this.f = this.g = !0;
+  }oa.prototype.load = function (a) {
+    this.c = new ca(this.j, a.context || this.j);this.g = !1 !== a.events;this.f = !1 !== a.classes;pa(this, new ha(this.c, a), a);
+  };
+  function qa(a, b, c, d, e) {
+    var f = 0 == --a.h;(a.f || a.g) && setTimeout(function () {
+      var a = e || null,
+          m = d || null || {};if (0 === c.length && f) L(b.a);else {
+        b.f += c.length;f && (b.j = f);var h,
+            l = [];for (h = 0; h < c.length; h++) {
+          var k = c[h],
+              n = m[k.c],
+              r = b.a,
+              x = k;r.g && w(r.f, [r.a.c("wf", x.c, J(x).toString(), "loading")]);K(r, "fontloading", x);r = null;if (null === X) if (window.FontFace) {
+            var x = /Gecko.*Firefox\/(\d+)/.exec(window.navigator.userAgent),
+                xa = /OS X.*Version\/10\..*Safari/.exec(window.navigator.userAgent) && /Apple/.exec(window.navigator.vendor);
+            X = x ? 42 < parseInt(x[1], 10) : xa ? !1 : !0;
+          } else X = !1;X ? r = new P(p(b.g, b), p(b.h, b), b.c, k, b.s, n) : r = new Q(p(b.g, b), p(b.h, b), b.c, k, b.s, a, n);l.push(r);
+        }for (h = 0; h < l.length; h++) {
+          l[h].start();
+        }
+      }
+    }, 0);
+  }function pa(a, b, c) {
+    var d = [],
+        e = c.timeout;ia(b);var d = ka(a.a, c, a.c),
+        f = new W(a.c, b, e);a.h = d.length;b = 0;for (c = d.length; b < c; b++) {
+      d[b].load(function (b, d, c) {
+        qa(a, f, b, d, c);
+      });
+    }
+  };function ra(a, b) {
+    this.c = a;this.a = b;
+  }
+  ra.prototype.load = function (a) {
+    function b() {
+      if (f["__mti_fntLst" + d]) {
+        var c = f["__mti_fntLst" + d](),
+            e = [],
+            h;if (c) for (var l = 0; l < c.length; l++) {
+          var k = c[l].fontfamily;void 0 != c[l].fontStyle && void 0 != c[l].fontWeight ? (h = c[l].fontStyle + c[l].fontWeight, e.push(new G(k, h))) : e.push(new G(k));
+        }a(e);
+      } else setTimeout(function () {
+        b();
+      }, 50);
+    }var c = this,
+        d = c.a.projectId,
+        e = c.a.version;if (d) {
+      var f = c.c.o;A(this.c, (c.a.api || "https://fast.fonts.net/jsapi") + "/" + d + ".js" + (e ? "?v=" + e : ""), function (e) {
+        e ? a([]) : (f["__MonotypeConfiguration__" + d] = function () {
+          return c.a;
+        }, b());
+      }).id = "__MonotypeAPIScript__" + d;
+    } else a([]);
+  };function sa(a, b) {
+    this.c = a;this.a = b;
+  }sa.prototype.load = function (a) {
+    var b,
+        c,
+        d = this.a.urls || [],
+        e = this.a.families || [],
+        f = this.a.testStrings || {},
+        g = new B();b = 0;for (c = d.length; b < c; b++) {
+      z(this.c, d[b], C(g));
+    }var m = [];b = 0;for (c = e.length; b < c; b++) {
+      if (d = e[b].split(":"), d[1]) for (var h = d[1].split(","), l = 0; l < h.length; l += 1) {
+        m.push(new G(d[0], h[l]));
+      } else m.push(new G(d[0]));
+    }E(g, function () {
+      a(m, f);
+    });
+  };function ta(a, b) {
+    a ? this.c = a : this.c = ua;this.a = [];this.f = [];this.g = b || "";
+  }var ua = "https://fonts.googleapis.com/css";function va(a, b) {
+    for (var c = b.length, d = 0; d < c; d++) {
+      var e = b[d].split(":");3 == e.length && a.f.push(e.pop());var f = "";2 == e.length && "" != e[1] && (f = ":");a.a.push(e.join(f));
+    }
+  }
+  function wa(a) {
+    if (0 == a.a.length) throw Error("No fonts to load!");if (-1 != a.c.indexOf("kit=")) return a.c;for (var b = a.a.length, c = [], d = 0; d < b; d++) {
+      c.push(a.a[d].replace(/ /g, "+"));
+    }b = a.c + "?family=" + c.join("%7C");0 < a.f.length && (b += "&subset=" + a.f.join(","));0 < a.g.length && (b += "&text=" + encodeURIComponent(a.g));return b;
+  };function ya(a) {
+    this.f = a;this.a = [];this.c = {};
+  }
+  var za = { latin: "BESbswy", "latin-ext": "\xE7\xF6\xFC\u011F\u015F", cyrillic: "\u0439\u044F\u0416", greek: "\u03B1\u03B2\u03A3", khmer: "\u1780\u1781\u1782", Hanuman: "\u1780\u1781\u1782" },
+      Aa = { thin: "1", extralight: "2", "extra-light": "2", ultralight: "2", "ultra-light": "2", light: "3", regular: "4", book: "4", medium: "5", "semi-bold": "6", semibold: "6", "demi-bold": "6", demibold: "6", bold: "7", "extra-bold": "8", extrabold: "8", "ultra-bold": "8", ultrabold: "8", black: "9", heavy: "9", l: "3", r: "4", b: "7" },
+      Ba = { i: "i", italic: "i", n: "n", normal: "n" },
+      Ca = /^(thin|(?:(?:extra|ultra)-?)?light|regular|book|medium|(?:(?:semi|demi|extra|ultra)-?)?bold|black|heavy|l|r|b|[1-9]00)?(n|i|normal|italic)?$/;
+  function Da(a) {
+    for (var b = a.f.length, c = 0; c < b; c++) {
+      var d = a.f[c].split(":"),
+          e = d[0].replace(/\+/g, " "),
+          f = ["n4"];if (2 <= d.length) {
+        var g;var m = d[1];g = [];if (m) for (var m = m.split(","), h = m.length, l = 0; l < h; l++) {
+          var k;k = m[l];if (k.match(/^[\w-]+$/)) {
+            var n = Ca.exec(k.toLowerCase());if (null == n) k = "";else {
+              k = n[2];k = null == k || "" == k ? "n" : Ba[k];n = n[1];if (null == n || "" == n) n = "4";else var r = Aa[n],
+                  n = r ? r : isNaN(n) ? "4" : n.substr(0, 1);k = [k, n].join("");
+            }
+          } else k = "";k && g.push(k);
+        }0 < g.length && (f = g);3 == d.length && (d = d[2], g = [], d = d ? d.split(",") : g, 0 < d.length && (d = za[d[0]]) && (a.c[e] = d));
+      }a.c[e] || (d = za[e]) && (a.c[e] = d);for (d = 0; d < f.length; d += 1) {
+        a.a.push(new G(e, f[d]));
+      }
+    }
+  };function Ea(a, b) {
+    this.c = a;this.a = b;
+  }var Fa = { Arimo: !0, Cousine: !0, Tinos: !0 };Ea.prototype.load = function (a) {
+    var b = new B(),
+        c = this.c,
+        d = new ta(this.a.api, this.a.text),
+        e = this.a.families;va(d, e);var f = new ya(e);Da(f);z(c, wa(d), C(b));E(b, function () {
+      a(f.a, f.c, Fa);
+    });
+  };function Ga(a, b) {
+    this.c = a;this.a = b;
+  }Ga.prototype.load = function (a) {
+    var b = this.a.id,
+        c = this.c.o;b ? A(this.c, (this.a.api || "https://use.typekit.net") + "/" + b + ".js", function (b) {
+      if (b) a([]);else if (c.Typekit && c.Typekit.config && c.Typekit.config.fn) {
+        b = c.Typekit.config.fn;for (var e = [], f = 0; f < b.length; f += 2) {
+          for (var g = b[f], m = b[f + 1], h = 0; h < m.length; h++) {
+            e.push(new G(g, m[h]));
+          }
+        }try {
+          c.Typekit.load({ events: !1, classes: !1, async: !0 });
+        } catch (l) {}a(e);
+      }
+    }, 2E3) : a([]);
+  };function Ha(a, b) {
+    this.c = a;this.f = b;this.a = [];
+  }Ha.prototype.load = function (a) {
+    var b = this.f.id,
+        c = this.c.o,
+        d = this;b ? (c.__webfontfontdeckmodule__ || (c.__webfontfontdeckmodule__ = {}), c.__webfontfontdeckmodule__[b] = function (b, c) {
+      for (var g = 0, m = c.fonts.length; g < m; ++g) {
+        var h = c.fonts[g];d.a.push(new G(h.name, ga("font-weight:" + h.weight + ";font-style:" + h.style)));
+      }a(d.a);
+    }, A(this.c, (this.f.api || "https://f.fontdeck.com/s/css/js/") + ea(this.c) + "/" + b + ".js", function (b) {
+      b && a([]);
+    })) : a([]);
+  };var Y = new oa(window);Y.a.c.custom = function (a, b) {
+    return new sa(b, a);
+  };Y.a.c.fontdeck = function (a, b) {
+    return new Ha(b, a);
+  };Y.a.c.monotype = function (a, b) {
+    return new ra(b, a);
+  };Y.a.c.typekit = function (a, b) {
+    return new Ga(b, a);
+  };Y.a.c.google = function (a, b) {
+    return new Ea(b, a);
+  };var Z = { load: p(Y.load, Y) };"function" === typeof define && define.amd ? define(function () {
+    return Z;
+  }) : "undefined" !== typeof module && module.exports ? module.exports = Z : (window.WebFont = Z, window.WebFontConfig && Y.load(window.WebFontConfig));
+})();
+
+},{}]},{},[1]);
+var _r=_m(1);_g.olms=_r;return _r;})})(typeof window!=='undefined'?window:(typeof global!=='undefined'?global:(typeof self!=='undefined'?self:this)));


### PR DESCRIPTION
## What does this PR do?
Adds an example using ol3 as a demo in the folder `openlayers`
use the same mapbox style json and use boundless style converter
https://github.com/boundlessgeo/ol-mapbox-style

### Screenshot
![bildschirmfoto 2017-07-18 um 19 02 42](https://user-images.githubusercontent.com/688980/28330093-8efce44e-6bec-11e7-8956-c0aaf337def8.png)

### Related Issue
resolves #13