### PR TITLE
Fix initial server variable

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -129,5 +129,5 @@ document.getElementById('city-switch').addEventListener('change', function(event
 })
 currentLib = mapbox;
 currentStyle = 'mapbox';
-currentServer = 'ec2';
+currentServer = config['ec2'];
 currentLib.init();


### PR DESCRIPTION
## What does this PR do?

It sets the `defaultServer` to the value of the config which is the actual server url. 
It worked for the first style but not for the rest, once you switched the server in the menu it worked again or switched the mapping library.